### PR TITLE
feat: 优化 harness gate 与验证证据复用

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: verify
+
+verify:
+	bash scripts/verify_harness_source.sh
+	bash tests/source_verify_contract_test.sh

--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ repo/
     ├── check.sh
     ├── common.sh
     ├── review_gate.sh
+    ├── evidence.sh
     ├── check.ps1
     ├── common.ps1
-    └── review_gate.ps1
+    ├── review_gate.ps1
+    └── evidence.ps1
 ```
 
 其中 plan 相关的三层关系固定为：
@@ -113,6 +115,16 @@ repo/
 - `sources/agent_adapters/` 只给特定 agent 使用，不进入 `init_harness_project.sh` / `init_harness_project.ps1` 的 managed files
 - `sources/agent_extensions/` 只给 agent 使用，不进入 `init_harness_project.sh` / `init_harness_project.ps1` 的 managed files
 
+## 两层验证入口
+
+源仓完整回归和目标仓日常检查是两个不同责任面：
+
+- 在本 harness 源仓执行 `make verify` 或 `bash scripts/verify_harness_source.sh`，运行精简 target check 后，再覆盖模板文案 contract、plan 模板与正反例矩阵、full / placeholder 源一致性、Bash / PowerShell 静态对齐和临时目标仓初始化。
+- Windows PowerShell 可执行 `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify_harness_source.ps1`（脚本路径 `scripts/verify_harness_source.ps1`）；源仓的 Bash 入口在检测到 PowerShell runtime 时也会调用它，否则明确报告只完成静态对齐检查。
+- 初始化后的目标仓执行 `make harness-check` / `make harness-verify`，只检查运行时关键不变量、review gate smoke 和 evidence helper 稳定性，不再用大量中文文案或完整 plan 矩阵阻塞目标项目日常开发。
+
+维护原则：修改 `template/`、初始化脚本或 `sources/agent_extensions/` 后，必须跑源仓完整回归；普通目标项目只需跑目标仓日常检查及项目自身验证命令。
+
 ## 推荐用法
 
 1. 先读 [init-harness-project-sop.md](init-harness-project-sop.md)
@@ -126,7 +138,8 @@ repo/
 9. 若存在 `.agents/prompts/maintenance-loop.md`，确认默认 mode 仍是 `report-only`
 10. 优先阅读 `.agents/PLANS.md`、`.agents/plans/TEMPLATE.md`、`.agents/plans/EXAMPLE-implementation.md`
 11. 按任务需要阅读 `.agents/skills/issue-goal-prompt/`、`.agents/skills/project-plan-archive/`、`.agents/skills/project-version-release/` 或 `.agents/skills/test-runbook/`
-12. macOS / Linux / Git Bash 执行 `make harness-verify`；Windows PowerShell 可执行 `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\harness\check.ps1`
+12. 在目标仓，macOS / Linux / Git Bash 执行 `make harness-verify`；Windows PowerShell 可执行 `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\harness\check.ps1`
+13. 在本 harness 源仓维护模板时，执行 `make verify`
 
 更推荐的 agent 用法是：
 

--- a/agent-init-project.md
+++ b/agent-init-project.md
@@ -88,9 +88,11 @@
    - `scripts/harness/check.sh`
    - `scripts/harness/common.sh`
    - `scripts/harness/review_gate.sh`
+   - `scripts/harness/evidence.sh`
    - `scripts/harness/check.ps1`
    - `scripts/harness/common.ps1`
    - `scripts/harness/review_gate.ps1`
+   - `scripts/harness/evidence.ps1`
 
    同时确认当前 base harness 的计划 contract 已经可读出：
 
@@ -280,7 +282,7 @@
    - `review_gate.sh` / `review_gate.ps1` 已明确会拒绝空的 `Reference Snippets` 和空的组件职责记录
    - `.agents/state/TEMPLATE.md` 与 `.agents/runs/TEMPLATE.md` 已明确它们只是本地辅助运行面
    - 如果生成了 `.cursor/rules/harness.mdc`，它已明确读取 harness 入口并要求 `make harness-verify`
-10. 最后在目标仓库执行 `make harness-verify`；Windows PowerShell 可执行 `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\harness\check.ps1`
+10. 最后在目标仓库执行 `make harness-verify`；Windows PowerShell 可执行 `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\harness\check.ps1`。这是目标仓日常 harness 检查，不替代项目自身验证命令。
 
 输出要求：
 1. 先说明当前在做 base harness、agent adapter 还是 agent 扩展层

--- a/init-harness-project-sop.md
+++ b/init-harness-project-sop.md
@@ -65,9 +65,11 @@ target-repo/
     ├── check.sh
     ├── common.sh
     ├── review_gate.sh
+    ├── evidence.sh
     ├── check.ps1
     ├── common.ps1
-    └── review_gate.ps1
+    ├── review_gate.ps1
+    └── evidence.ps1
 ```
 
 固定规则：
@@ -354,6 +356,7 @@ sources/agent_adapters/cursor/.cursor/rules/harness.mdc
   - `Concrete Steps` 需要拆成 `### 实现步骤` 与 `### 验证与收口步骤`
   - `TEMPLATE.md` 默认采用“实现优先”结构：`0. 现有架构回顾与核心设计决策 -> 1..N 改动面 -> 数据流可视化 -> 关键设计决策摘要 -> 与现有代码的关系`
 - `scripts/harness/review_gate.sh` 与 `scripts/harness/review_gate.ps1` 除了读取 `blocking_findings`，还要对 plan 做结构型轻量 lint，拒绝缺少实现骨架或仍保留明显占位内容的计划
+- `scripts/harness/evidence.sh` 与 `scripts/harness/evidence.ps1` 只读生成 `head`、`worktree_digest`、`evidence_id`、`reusable` 和 `reason`
 - `Reference Snippets` 不能是空块或纯占位内容
 - `组件职责与代码落点` 至少要有一条真实模块 / 路径 / 类型记录
 - `.agents/prompts/` 与 `.agents/guides/` 由 agent 驱动初始化时补充
@@ -424,9 +427,11 @@ sources/agent_extensions/
 - `check.sh`
 - `common.sh`
 - `review_gate.sh`
+- `evidence.sh`
 - `check.ps1`
 - `common.ps1`
 - `review_gate.ps1`
+- `evidence.ps1`
 
 固定要求：
 

--- a/scripts/init_harness_project.ps1
+++ b/scripts/init_harness_project.ps1
@@ -295,9 +295,11 @@ $managedFiles = @(
     "scripts/harness/check.sh",
     "scripts/harness/common.sh",
     "scripts/harness/review_gate.sh",
+    "scripts/harness/evidence.sh",
     "scripts/harness/check.ps1",
     "scripts/harness/common.ps1",
-    "scripts/harness/review_gate.ps1"
+    "scripts/harness/review_gate.ps1",
+    "scripts/harness/evidence.ps1"
 )
 
 foreach ($rel in $managedFiles) {

--- a/scripts/init_harness_project.sh
+++ b/scripts/init_harness_project.sh
@@ -350,9 +350,11 @@ managed_files=(
   "scripts/harness/check.sh"
   "scripts/harness/common.sh"
   "scripts/harness/review_gate.sh"
+  "scripts/harness/evidence.sh"
   "scripts/harness/check.ps1"
   "scripts/harness/common.ps1"
   "scripts/harness/review_gate.ps1"
+  "scripts/harness/evidence.ps1"
 )
 
 for rel in "${managed_files[@]}"; do

--- a/scripts/verify_harness_source.ps1
+++ b/scripts/verify_harness_source.ps1
@@ -1,0 +1,439 @@
+param()
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$TemplateRoot = Join-Path $RepoRoot "template"
+
+function Assert-SourcePatterns {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string[]]$Patterns
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "harness source verify: missing source contract file: $Path"
+    }
+
+    $Content = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+    foreach ($Pattern in $Patterns) {
+        if (-not $Content.Contains($Pattern)) {
+            throw "harness source verify: $Path missing source contract: $Pattern"
+        }
+    }
+}
+
+function Get-CurrentPowerShellExecutable {
+    $Process = Get-Process -Id $PID
+    if ($null -eq $Process -or [string]::IsNullOrWhiteSpace($Process.Path)) {
+        throw "harness source verify: unable to locate current PowerShell executable"
+    }
+    return $Process.Path
+}
+
+function Invoke-PowerShellScriptProcess {
+    param(
+        [Parameter(Mandatory = $true)][string]$ScriptPath,
+        [object[]]$ScriptArguments = @(),
+        [bool]$ShouldPass = $true,
+        [Parameter(Mandatory = $true)][string]$FailureMessage,
+        [switch]$Quiet
+    )
+
+    $Executable = Get-CurrentPowerShellExecutable
+    $Arguments = @("-NoProfile")
+    if ((Split-Path -Leaf $Executable) -ieq "powershell.exe") {
+        $Arguments += @("-ExecutionPolicy", "Bypass")
+    }
+    $Arguments += @("-File", $ScriptPath)
+    $Arguments += $ScriptArguments
+
+    if ($Quiet) {
+        & $Executable @Arguments *> $null
+    }
+    else {
+        & $Executable @Arguments
+    }
+    $Passed = ($LASTEXITCODE -eq 0)
+    if ($Passed -ne $ShouldPass) {
+        throw "harness source verify: $FailureMessage"
+    }
+}
+
+function Write-Utf8NoBom {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Content
+    )
+
+    $Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $Content, $Utf8NoBom)
+}
+
+Invoke-PowerShellScriptProcess `
+    -ScriptPath (Join-Path $TemplateRoot "scripts/harness/check.ps1") `
+    -FailureMessage "target runtime check failed"
+
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot "docs/harness/control-plane.md") -Patterns @(
+    "collect -> gate -> freeze -> slice -> dispatch -> implement -> verify -> review -> integrate -> verify -> writeback -> pr_prep -> merge -> notify",
+    "Issue Tracker 是主协作真相",
+    "write_lease",
+    "Current State",
+    "Thread Status",
+    "post-integration verify",
+    "Maintenance Loop",
+    ".agents/PLANS.md",
+    "Review Policy Contract",
+    '`review_policy`: `standard` / `strict`',
+    '`standard` 允许主 agent 执行对抗式自审',
+    '`strict` 必须由 subagent 独立评审',
+    "多仓代码改动、多个可写 lease 或 branch / worktree 集成",
+    "鉴权、安全、权限、公开 API 或 contract 兼容性",
+    "schema、migration 或数据修改",
+    "并发、幂等、重试或业务状态机",
+    "release、部署、生产环境或不可逆外部副作用",
+    "required live E2E、full-auto 或自动 merge",
+    "风险无法可靠判断",
+    "Verification Evidence Reuse Contract",
+    "deterministic-local",
+    "environment-dependent",
+    "任何无法确认的情况默认重跑"
+)
+
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot "docs/harness/issue-workflow.md") -Patterns @(
+    "Orchestration Contract",
+    "Current State Comment Contract",
+    "Thread Status Comment Contract",
+    "Write Lease Contract",
+    "Post-Integration Verify Contract",
+    "current_issue_state",
+    "recovery_point",
+    "next_action"
+)
+
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot "docs/harness/project-constraints.md") -Patterns @(
+    "Project Mechanical Constraints",
+    "状态枚举",
+    "分类枚举",
+    "enforced",
+    "not_applicable",
+    "security",
+    "cross-repo",
+    "Maintenance Tag",
+    "rule_promotion_candidate",
+    "human_decision_required",
+    "project-check"
+)
+
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot "docs/harness/linear.md") -Patterns @(
+    "Linear Profile",
+    "current_issue_state",
+    "Current State",
+    "Thread Status",
+    "write_lease",
+    "post-integration verify",
+    "recovery_point",
+    "next_action"
+)
+
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot "docs/test/RUNBOOK_TEMPLATE.md") -Patterns @(
+    "Test Runbook Template",
+    "当前验证结果",
+    "本次执行结果",
+    "执行副作用",
+    "前置条件",
+    "测试变量 / 初始化",
+    "主路径",
+    "清理结果",
+    "结果回写"
+)
+
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot ".agents/PLANS.md") -Patterns @(
+    "计划文档最小结构",
+    "真实入口与触发",
+    "输入装配与边界校验",
+    "组件职责与代码落点",
+    "关键执行时序",
+    "停止 / 错误 / 恢复",
+    "Reference Snippets",
+    "Mermaid 使用规则"
+)
+
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot ".agents/plans/TEMPLATE.md") -Patterns @(
+    "## 0. 现有架构回顾与核心设计决策",
+    "### 真实入口与触发",
+    "### 输入装配与边界校验",
+    "### 组件职责与代码落点",
+    "### 关键执行时序",
+    "### 停止 / 错误 / 恢复",
+    "## Reference Snippets",
+    "### 实现步骤",
+    "### 验证与收口步骤",
+    "## Outcomes & Retrospective"
+)
+
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot ".agents/skills/issue-goal-prompt/SKILL.md") -Patterns @(
+    '派生 `review_policy`',
+    '兼容性默认值是 `strict`',
+    "对抗式自审",
+    "验证证据复用",
+    "subagent_review_unavailable",
+    "manual_gate_live_e2e"
+)
+
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot ".agents/skills/issue-goal-prompt/references/goal-prompt-template.md") -Patterns @(
+    "- review_policy: <standard|strict>",
+    "- subagent_review_required: <true|false>",
+    "review_owner: main-agent-self-review",
+    "review_owner: subagent",
+    '`evidence_id`',
+    '`execution_session_id`',
+    '`post_integration_verify_summary.status`: `reused`'
+)
+
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot "scripts/harness/common.ps1") -Patterns @(
+    "Get-PlanImplementationSkeletonErrors",
+    "Resolve-PlanImplementationSection",
+    "Reference Snippets",
+    "组件职责与代码落点"
+)
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot "scripts/harness/review_gate.ps1") -Patterns @(
+    "blocking_findings",
+    "result=pass",
+    "result=fail"
+)
+Assert-SourcePatterns -Path (Join-Path $TemplateRoot "scripts/harness/evidence.ps1") -Patterns @(
+    "result=",
+    "head=",
+    "worktree_digest=",
+    "evidence_id=",
+    "reusable=",
+    "reason="
+)
+
+$FullRoot = Join-Path $RepoRoot "sources/agent_extensions/full"
+$PlaceholderRoot = Join-Path $RepoRoot "sources/agent_extensions/placeholder"
+$FullFiles = Get-ChildItem -LiteralPath $FullRoot -File -Recurse | ForEach-Object {
+    $_.FullName.Substring($FullRoot.Length).TrimStart([IO.Path]::DirectorySeparatorChar).Replace("\", "/")
+} | Sort-Object
+$PlaceholderFiles = Get-ChildItem -LiteralPath $PlaceholderRoot -File -Recurse | ForEach-Object {
+    $_.FullName.Substring($PlaceholderRoot.Length).TrimStart([IO.Path]::DirectorySeparatorChar).Replace("\", "/")
+} | Sort-Object
+
+if (Compare-Object -ReferenceObject $FullFiles -DifferenceObject $PlaceholderFiles) {
+    throw "harness source verify: full and placeholder extension bundles have different file sets"
+}
+
+foreach ($RelativePath in $FullFiles) {
+    Assert-SourcePatterns -Path (Join-Path $FullRoot $RelativePath) -Patterns @("Mode: full")
+    Assert-SourcePatterns -Path (Join-Path $PlaceholderRoot $RelativePath) -Patterns @("Mode: placeholder")
+}
+
+foreach ($ModeRoot in @($FullRoot, $PlaceholderRoot)) {
+    Assert-SourcePatterns -Path (Join-Path $ModeRoot ".agents/prompts/issue-standard-workflow.md") -Patterns @(
+        "review_policy",
+        "subagent_review_required",
+        "evidence_id",
+        "deterministic-local",
+        "environment-dependent",
+        "reused"
+    )
+    Assert-SourcePatterns -Path (Join-Path $ModeRoot ".agents/prompts/loop-codex.md") -Patterns @(
+        "review_policy",
+        "subagent_review_required",
+        "evidence_id",
+        "required live E2E"
+    )
+    Assert-SourcePatterns -Path (Join-Path $ModeRoot ".agents/prompts/loop-automation.md") -Patterns @(
+        "review_policy",
+        "evidence_id",
+        "任何无法确认的情况默认重跑"
+    )
+    Assert-SourcePatterns -Path (Join-Path $ModeRoot ".agents/prompts/orchestrator-thread.md") -Patterns @(
+        "review_policy",
+        "subagent_review_required",
+        "post_integration_verify_summary.status",
+        "reused"
+    )
+    Assert-SourcePatterns -Path (Join-Path $ModeRoot ".agents/guides/code-review.md") -Patterns @(
+        "Review Policy",
+        "main-agent-self-review",
+        "subagent",
+        "blocking_findings",
+        "对抗式自审"
+    )
+}
+
+Assert-SourcePatterns -Path (Join-Path $FullRoot ".agents/prompts/orchestrator-thread.md") -Patterns @(
+    "goal-orchestration",
+    "write_lease",
+    "Current State",
+    "Thread Status",
+    "post-integration verify",
+    "waiting_on_child"
+)
+Assert-SourcePatterns -Path (Join-Path $FullRoot ".agents/prompts/maintenance-loop.md") -Patterns @(
+    "report-only",
+    "issue-create",
+    "safe-fix",
+    "rule-promotion",
+    "Maintenance Findings",
+    "Verification Plan",
+    "Residual Risks",
+    "Next Action"
+)
+
+$ValidPlan = Join-Path $TemplateRoot ".agents/plans/EXAMPLE-implementation.md"
+$ReviewGate = Join-Path $TemplateRoot "scripts/harness/review_gate.ps1"
+Invoke-PowerShellScriptProcess -ScriptPath $ReviewGate -ScriptArguments @("-Plan", $ValidPlan) `
+    -FailureMessage "PowerShell review gate rejected the exemplar" -Quiet
+
+$PlanTempRoot = Join-Path ([IO.Path]::GetTempPath()) ("harness-plan-matrix-" + [Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $PlanTempRoot -Force | Out-Null
+try {
+    $ValidPlanText = [System.IO.File]::ReadAllText($ValidPlan)
+    $PlanCases = @(
+        @{
+            Name = "bad-blocking.md"
+            Content = $ValidPlanText.Replace('`blocking_findings`: none', '`blocking_findings`: correctness regression')
+            Label = "blocking finding"
+        },
+        @{
+            Name = "bad-steps.md"
+            Content = $ValidPlanText.Replace("步骤化时序", "执行顺序")
+            Label = "missing step-by-step sequence"
+        },
+        @{
+            Name = "bad-core.md"
+            Content = $ValidPlanText.Replace("装配结果 / 核心对象", "装配产物")
+            Label = "missing assembled core object"
+        },
+        @{
+            Name = "bad-branch.md"
+            Content = $ValidPlanText.Replace("关键分支 / 降级路径", "异常分支")
+            Label = "missing key branch"
+        },
+        @{
+            Name = "bad-snippets.md"
+            Content = $ValidPlanText.Replace("## Reference Snippets", "## Reference Samples")
+            Label = "missing reference snippets"
+        }
+    )
+
+    foreach ($Case in $PlanCases) {
+        $CasePath = Join-Path $PlanTempRoot $Case.Name
+        Write-Utf8NoBom -Path $CasePath -Content $Case.Content
+        Invoke-PowerShellScriptProcess -ScriptPath $ReviewGate -ScriptArguments @("-Plan", $CasePath) `
+            -ShouldPass $false -FailureMessage "PowerShell review gate accepted invalid plan: $($Case.Label)" -Quiet
+    }
+
+    $LegacyPlan = Join-Path $PlanTempRoot "legacy-plan.md"
+    Write-Utf8NoBom -Path $LegacyPlan -Content $ValidPlanText.Replace(
+        "## 0. 现有架构回顾与核心设计决策",
+        "## Architecture / Data Flow"
+    )
+    Invoke-PowerShellScriptProcess -ScriptPath $ReviewGate -ScriptArguments @("-Plan", $LegacyPlan) `
+        -FailureMessage "PowerShell review gate rejected the legacy implementation section" -Quiet
+
+    $ComponentStart = $ValidPlanText.IndexOf("### 组件职责与代码落点", [StringComparison]::Ordinal)
+    $ComponentEnd = $ValidPlanText.IndexOf("### 关键执行时序", $ComponentStart, [StringComparison]::Ordinal)
+    if ($ComponentStart -lt 0 -or $ComponentEnd -lt 0) {
+        throw "harness source verify: unable to construct missing-component-row plan fixture"
+    }
+    $ComponentSection = $ValidPlanText.Substring($ComponentStart, $ComponentEnd - $ComponentStart)
+    $ComponentLines = $ComponentSection -split '\r?\n'
+    $KeptComponentLines = $ComponentLines | Where-Object {
+        -not ($_.StartsWith("|") -and -not $_.Contains("---") -and -not $_.Contains("模块/类型"))
+    }
+    $BadComponentText = $ValidPlanText.Substring(0, $ComponentStart) +
+        ($KeptComponentLines -join [Environment]::NewLine) + [Environment]::NewLine +
+        $ValidPlanText.Substring($ComponentEnd)
+    $BadComponent = Join-Path $PlanTempRoot "bad-component.md"
+    Write-Utf8NoBom -Path $BadComponent -Content $BadComponentText
+    Invoke-PowerShellScriptProcess -ScriptPath $ReviewGate -ScriptArguments @("-Plan", $BadComponent) `
+        -ShouldPass $false -FailureMessage "PowerShell review gate accepted invalid plan: missing component row" -Quiet
+
+    $BadHarnessFlow = Join-Path $PlanTempRoot "bad-harness-flow.md"
+    Write-Utf8NoBom -Path $BadHarnessFlow -Content @'
+# ExecPlan: harness-only flow
+
+## Architecture / Data Flow
+
+```mermaid
+flowchart TD
+  Collect["collect"] --> Verify["verify"]
+```
+
+## Reference Snippets
+
+```text
+result=pass
+```
+
+## Concrete Steps
+
+### 实现步骤
+1. 运行控制面。
+
+## Review Summary
+- `blocking_findings`: none
+'@
+    Invoke-PowerShellScriptProcess -ScriptPath $ReviewGate -ScriptArguments @("-Plan", $BadHarnessFlow) `
+        -ShouldPass $false -FailureMessage "PowerShell review gate accepted invalid plan: harness-only flow" -Quiet
+}
+finally {
+    Remove-Item -LiteralPath $PlanTempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$TempTarget = Join-Path ([IO.Path]::GetTempPath()) ("harness-source-verify-" + [Guid]::NewGuid().ToString("N"))
+try {
+    $RunningOnWindows = ($env:OS -eq "Windows_NT") -or ([IO.Path]::DirectorySeparatorChar -eq [char]'\')
+    $Initializer = Join-Path $RepoRoot "scripts/init_harness_project.ps1"
+    if ($RunningOnWindows) {
+        Invoke-PowerShellScriptProcess -ScriptPath $Initializer -ScriptArguments @(
+            "-Target", $TempTarget,
+            "-ProjectName", "Harness Source Verify",
+            "-Stack", "go",
+            "-Provider", "neutral",
+            "-IssueProvider", "linear",
+            "-IssuePrefix", "HSV"
+        ) -FailureMessage "PowerShell initializer failed" -Quiet
+
+        Push-Location $TempTarget
+        try {
+            Invoke-PowerShellScriptProcess -ScriptPath (Join-Path $TempTarget "scripts/harness/check.ps1") `
+                -FailureMessage "initialized target failed PowerShell target check" -Quiet
+        }
+        finally {
+            Pop-Location
+        }
+    }
+    else {
+        Invoke-PowerShellScriptProcess -ScriptPath $Initializer -ScriptArguments @("-DryRun") `
+            -FailureMessage "PowerShell initializer dry run failed" -Quiet
+        Write-Output "PowerShell initializer temp-target smoke: skipped on non-Windows native path contract"
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $TempTarget) {
+        Remove-Item -LiteralPath $TempTarget -Recurse -Force
+    }
+}
+
+$Python = Get-Command python3 -ErrorAction SilentlyContinue
+if ($null -ne $Python) {
+    $env:PYTHONDONTWRITEBYTECODE = "1"
+    & $Python.Source (Join-Path $TemplateRoot ".agents/skills/project-plan-archive/tests/test_project_plan_archive.py") | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "harness source verify: project plan archive tests failed"
+    }
+    & $Python.Source (Join-Path $TemplateRoot ".agents/skills/project-version-release/scripts/project_version_release.py") --help | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "harness source verify: project version release helper failed"
+    }
+}
+else {
+    throw "harness source verify: python3 is required"
+}
+
+Write-Output "harness source verify passed"

--- a/scripts/verify_harness_source.sh
+++ b/scripts/verify_harness_source.sh
@@ -1,0 +1,642 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+template_root="$repo_root/template"
+
+fail() {
+  echo "harness source verify: $*" >&2
+  exit 1
+}
+
+assert_patterns() {
+  local path="$1"
+  shift
+  local pattern
+
+  [[ -f "$path" ]] || fail "missing source contract file: ${path#$repo_root/}"
+  for pattern in "$@"; do
+    rg -Fq -- "$pattern" "$path" \
+      || fail "${path#$repo_root/} missing source contract: $pattern"
+  done
+}
+
+assert_patterns_any() {
+  local label="$1"
+  local paths="$2"
+  shift 2
+  local pattern
+
+  for pattern in "$@"; do
+    if ! rg -Fq -- "$pattern" $paths; then
+      fail "$label missing source contract: $pattern"
+    fi
+  done
+}
+
+assert_plan_rejected() {
+  local plan="$1"
+  local label="$2"
+
+  if bash "$template_root/scripts/harness/review_gate.sh" --plan "$plan" >/dev/null 2>&1; then
+    fail "review gate accepted invalid plan: $label"
+  fi
+}
+
+required_source_files=(
+  "README.md"
+  "agent-init-project.md"
+  "init-harness-project-sop.md"
+  "scripts/init_harness_project.sh"
+  "scripts/init_harness_project.ps1"
+  "scripts/verify_harness_source.sh"
+  "scripts/verify_harness_source.ps1"
+  "template/scripts/harness/check.sh"
+  "template/scripts/harness/check.ps1"
+  "template/scripts/harness/common.sh"
+  "template/scripts/harness/common.ps1"
+  "template/scripts/harness/review_gate.sh"
+  "template/scripts/harness/review_gate.ps1"
+  "template/scripts/harness/evidence.sh"
+  "template/scripts/harness/evidence.ps1"
+)
+
+for path in "${required_source_files[@]}"; do
+  [[ -f "$repo_root/$path" ]] || fail "missing source file: $path"
+done
+
+assert_patterns "$repo_root/README.md" \
+  "make verify" \
+  "源仓完整回归" \
+  "目标仓日常检查" \
+  "scripts/verify_harness_source.sh" \
+  "scripts/verify_harness_source.ps1"
+
+assert_patterns "$repo_root/scripts/init_harness_project.sh" \
+  '"scripts/harness/evidence.sh"' \
+  '"scripts/harness/evidence.ps1"'
+assert_patterns "$repo_root/scripts/init_harness_project.ps1" \
+  '"scripts/harness/evidence.sh"' \
+  '"scripts/harness/evidence.ps1"'
+
+assert_patterns "$template_root/README.md" \
+  "scripts/harness/evidence.sh snapshot" \
+  "harness-verify"
+assert_patterns "$template_root/AGENTS.md" \
+  "scripts/harness/evidence.sh snapshot" \
+  "review_policy"
+
+(
+  cd "$template_root"
+  bash scripts/harness/check.sh
+)
+
+for path in "$template_root/README.md" "$template_root/AGENTS.md"; do
+  rg -Fq "EXAMPLE-implementation.md" "$path" \
+    || fail "${path#$repo_root/} should point readers to EXAMPLE-implementation.md"
+done
+if rg -n '^docs/test' "$template_root/.gitignore" >/dev/null; then
+  fail "template/.gitignore should not ignore docs/test runbook documents"
+fi
+
+assert_patterns "$template_root/docs/harness/control-plane.md" \
+  "collect -> gate -> freeze -> slice -> dispatch -> implement -> verify -> review -> integrate -> verify -> writeback -> pr_prep -> merge -> notify" \
+  "Issue Tracker 是主协作真相" \
+  "repo 是主执行真相" \
+  "goal-orchestration" \
+  "write_lease" \
+  "Current State" \
+  "Thread Status" \
+  "post-integration verify" \
+  "waiting_on_child" \
+  "【完成】" \
+  "Issue Store Profiles" \
+  "provider 仓" \
+  "consumer 仓" \
+  "project-constraints.md" \
+  "Maintenance Loop" \
+  "report-only" \
+  "rule-promotion" \
+  "review_gate" \
+  ".agents/PLANS.md" \
+  ".agents/plans/TEMPLATE.md" \
+  "Review Policy Contract" \
+  '`review_policy`: `standard` / `strict`' \
+  '`standard` 允许主 agent 执行对抗式自审' \
+  '`strict` 必须由 subagent 独立评审' \
+  "多仓代码改动、多个可写 lease 或 branch / worktree 集成" \
+  "鉴权、安全、权限、公开 API 或 contract 兼容性" \
+  "schema、migration 或数据修改" \
+  "并发、幂等、重试或业务状态机" \
+  "release、部署、生产环境或不可逆外部副作用" \
+  "required live E2E、full-auto 或自动 merge" \
+  "风险无法可靠判断" \
+  "Verification Evidence Reuse Contract" \
+  "deterministic-local" \
+  "environment-dependent" \
+  "任何无法确认的情况默认重跑"
+
+assert_patterns "$template_root/docs/harness/issue-workflow.md" \
+  "Issue Workflow" \
+  "Issue Tracker 是主协作真相" \
+  "Issue Store Profiles" \
+  "Orchestration Contract" \
+  "Current State Comment Contract" \
+  "Thread Status Comment Contract" \
+  "Write Lease Contract" \
+  "Post-Integration Verify Contract" \
+  "goal-orchestration" \
+  "write_lease" \
+  "Requirement Clarification" \
+  "Master Issue" \
+  "Execution Issue" \
+  "Codex Handoff" \
+  "recovery_point" \
+  "next_action" \
+  "current_issue_state" \
+  "Master 是否可置 Done"
+
+assert_patterns_any "docs/issues templates" \
+  "$template_root/docs/issues/README.md $template_root/docs/issues/TEMPLATE.md" \
+  "Repo Issues" \
+  "issue-provider=repo" \
+  "issue_id" \
+  "status" \
+  "kind" \
+  "goal" \
+  "included" \
+  "excluded" \
+  "acceptance_matrix" \
+  "stop_when" \
+  "write_scope_limit" \
+  "verification_commands" \
+  "recovery_point" \
+  "next_action" \
+  "Orchestration" \
+  "Current State" \
+  "Thread Status Log" \
+  "active_write_leases" \
+  "post_integration_verify_summary" \
+  "writeback_log"
+
+assert_patterns "$template_root/docs/harness/project-constraints.md" \
+  "Project Mechanical Constraints" \
+  "状态枚举" \
+  "分类枚举" \
+  "enforced" \
+  "partial" \
+  "documented" \
+  "planned" \
+  "not_applicable" \
+  "architecture" \
+  "contract" \
+  "runtime" \
+  "verification" \
+  "docs" \
+  "security" \
+  "cross-repo" \
+  "维护循环关联" \
+  "maintenance_candidate" \
+  "rule_promotion_candidate" \
+  "human_decision_required" \
+  "Maintenance Tag" \
+  "Rule ID | Category | Rule | Source | Enforcement | Command | Status | Maintenance Tag | Notes" \
+  "project-check" \
+  '没有可执行命令或 gate 时，不得假装 `enforced`' \
+  "repeated review finding"
+
+assert_patterns "$template_root/docs/harness/linear.md" \
+  "Linear Profile" \
+  "issue-workflow.md" \
+  "Linear 字段映射" \
+  "current_issue_state" \
+  "Current State" \
+  "Thread Status" \
+  "write_lease" \
+  "post-integration verify" \
+  "【完成】" \
+  "recovery_point" \
+  "next_action" \
+  "Issue Tracker 是主协作真相"
+
+assert_patterns "$template_root/docs/test/RUNBOOK_TEMPLATE.md" \
+  "Test Runbook Template" \
+  "当前验证结果" \
+  "本次执行结果" \
+  "执行副作用" \
+  "前置条件" \
+  "测试变量 / 初始化" \
+  "主路径" \
+  "清理结果" \
+  "结果回写" \
+  "runbook"
+
+assert_patterns "$template_root/.agents/PLANS.md" \
+  "文档定位" \
+  "计划实例位置" \
+  "何时必须写 plan" \
+  "计划文档最小结构" \
+  "技术实现型任务推荐写法" \
+  "EXAMPLE-implementation.md" \
+  "真实入口与触发" \
+  "输入装配与边界校验" \
+  "组件职责与代码落点" \
+  "关键执行时序" \
+  "停止 / 错误 / 恢复" \
+  "入口代码位置" \
+  "装配结果 / 核心对象" \
+  "步骤化时序" \
+  "关键分支 / 降级路径" \
+  "Reference Snippets" \
+  "File Map" \
+  "伪代码 / 主循环" \
+  "关键分支与实现策略" \
+  "竞态 / 状态机分析" \
+  "Mermaid 使用规则" \
+  "代码示例使用规则" \
+  "Maintenance Loop 计划要求" \
+  "Maintenance Findings" \
+  "Issue Tracker 默认约定"
+
+assert_patterns "$template_root/.agents/plans/TEMPLATE.md" \
+  "name: <任务名>" \
+  "overview:" \
+  "todos:" \
+  "isProject: false" \
+  "## Goal" \
+  "## Scope Freeze" \
+  "## Context and Orientation" \
+  "## 0. 现有架构回顾与核心设计决策" \
+  "### 真实入口与触发" \
+  "入口代码位置" \
+  "### 输入装配与边界校验" \
+  "装配结果 / 核心对象" \
+  "### 组件职责与代码落点" \
+  "关键产物" \
+  "### 关键执行时序" \
+  "步骤化时序" \
+  "### 停止 / 错误 / 恢复" \
+  "关键分支 / 降级路径" \
+  "## 数据流可视化" \
+  "## 关键设计决策摘要" \
+  "## 与现有代码的关系" \
+  "## File Map（按需）" \
+  "## 关键分支与实现策略（按需）" \
+  "## 伪代码 / 主循环（按需）" \
+  "## 竞态 / 状态机分析（按需）" \
+  "## Reference Snippets" \
+  "## Concrete Steps" \
+  "### 实现步骤" \
+  "### 验证与收口步骤" \
+  "## Progress" \
+  "## Decision Log" \
+  "## Surprises & Discoveries" \
+  "## Validation and Acceptance" \
+  "## Idempotence and Recovery" \
+  "## Outcomes & Retrospective"
+
+for field in \
+  issue_provider issue_project current_issue_state recovery_point next_action \
+  state_ref latest_run_ref master_run_ref; do
+  rg -Fq -- "$field" "$template_root/.agents/plans/TEMPLATE.md" \
+    || fail "plan template missing issue/state field: $field"
+done
+
+assert_patterns "$template_root/.agents/plans/EXAMPLE-implementation.md" \
+  "## Goal" \
+  "## 0. 现有架构回顾与核心设计决策" \
+  "## 1. HTTP 入口层 -- 收口请求与幂等键" \
+  "## 数据流可视化" \
+  "## 关键设计决策摘要" \
+  "## 与现有代码的关系" \
+  "## Reference Snippets" \
+  "## Review Summary"
+
+assert_patterns "$template_root/.agents/state/TEMPLATE.md" \
+  "State Snapshot Template" \
+  "Issue Tracker" \
+  "orchestration_mode" \
+  "root_goal" \
+  "goal_state" \
+  "goal_unit_roster" \
+  "active_write_leases" \
+  "waiting_on" \
+  "next_check" \
+  "post_integration_verify" \
+  "recovery_point"
+
+assert_patterns "$template_root/.agents/runs/TEMPLATE.md" \
+  "Run Summary Template" \
+  "Issue Tracker" \
+  "orchestration_mode" \
+  "root_goal" \
+  "goal_state" \
+  "active_write_leases" \
+  "post_integration_verify"
+
+assert_patterns "$template_root/.agents/skills/issue-goal-prompt/SKILL.md" \
+  "任务系统" \
+  "状态文件规则" \
+  "pre-commit ready" \
+  "subagent_review_unavailable" \
+  "manual_gate_live_e2e" \
+  '派生 `review_policy`' \
+  '兼容性默认值是 `strict`' \
+  "对抗式自审" \
+  "验证证据复用"
+
+assert_patterns "$template_root/.agents/skills/issue-goal-prompt/references/goal-prompt-template.md" \
+  "完整目标提示词" \
+  "状态文件模板" \
+  "短启动提示词" \
+  '- review_policy: <standard|strict>' \
+  '- subagent_review_required: <true|false>' \
+  "review_owner: main-agent-self-review" \
+  "review_owner: subagent" \
+  '`evidence_id`' \
+  '`execution_session_id`' \
+  '`post_integration_verify_summary.status`: `reused`'
+
+assert_patterns "$template_root/.agents/skills/project-plan-archive/SKILL.md" \
+  "先查 Issue Tracker，再归档" \
+  "--done-issue" \
+  "no_issue_default_archive"
+
+assert_patterns "$template_root/.agents/skills/project-version-release/SKILL.md" \
+  "issue 是执行粒度，release 是发布粒度" \
+  "CHANGELOG.md -> Unreleased"
+
+assert_patterns "$template_root/.agents/skills/test-runbook/SKILL.md" \
+  "执行副作用" \
+  "Request / Response 回写规则" \
+  "提交版证据边界" \
+  "结果回写规则"
+
+if rg -n "DBBridge|db_bridge_test|/Users/suqing|TEA-" "$template_root/.agents/skills" >/dev/null; then
+  fail "default harness skills contain project-specific constants"
+fi
+
+assert_patterns "$template_root/scripts/harness/common.ps1" \
+  "Get-PlanImplementationSkeletonErrors" \
+  "Resolve-PlanImplementationSection" \
+  "Reference Snippets" \
+  "组件职责与代码落点"
+assert_patterns "$template_root/scripts/harness/review_gate.ps1" \
+  "blocking_findings" \
+  "result=pass" \
+  "result=fail"
+assert_patterns "$template_root/scripts/harness/evidence.ps1" \
+  "result=" \
+  "head=" \
+  "worktree_digest=" \
+  "evidence_id=" \
+  "reusable=" \
+  "reason="
+
+assert_patterns "$repo_root/scripts/verify_harness_source.ps1" \
+  "Maintenance Loop" \
+  "Reference Snippets" \
+  "Get-PlanImplementationSkeletonErrors" \
+  "full and placeholder extension bundles have different file sets" \
+  "init_harness_project.ps1" \
+  "harness source verify passed"
+
+full_root="$repo_root/sources/agent_extensions/full"
+placeholder_root="$repo_root/sources/agent_extensions/placeholder"
+shared_root="$repo_root/sources/agent_extensions/shared"
+
+full_files="$(cd "$full_root" && find . -type f -print | sort)"
+placeholder_files="$(cd "$placeholder_root" && find . -type f -print | sort)"
+[[ "$full_files" == "$placeholder_files" ]] \
+  || fail "full and placeholder extension bundles have different file sets"
+[[ -f "$shared_root/.agents/prompts/README.md" ]] \
+  || fail "shared extension bundle is missing prompt README"
+
+assert_patterns "$shared_root/.agents/prompts/README.md" \
+  "orchestrator-thread.md" \
+  "issue-standard-workflow.md" \
+  "loop-codex.md" \
+  "loop-automation.md" \
+  "maintenance-loop.md"
+
+for mode_root in "$full_root" "$placeholder_root"; do
+  assert_patterns "$mode_root/.agents/guides/linter.md" \
+    "docs/harness/project-constraints.md"
+  assert_patterns "$mode_root/.agents/prompts/issue-standard-workflow.md" \
+    "review_policy" \
+    "subagent_review_required" \
+    "evidence_id" \
+    "deterministic-local" \
+    "environment-dependent" \
+    "reused"
+  assert_patterns "$mode_root/.agents/prompts/loop-codex.md" \
+    "review_policy" \
+    "subagent_review_required" \
+    "evidence_id" \
+    "required live E2E"
+  assert_patterns "$mode_root/.agents/prompts/loop-automation.md" \
+    "review_policy" \
+    "evidence_id" \
+    "任何无法确认的情况默认重跑"
+  assert_patterns "$mode_root/.agents/prompts/orchestrator-thread.md" \
+    "review_policy" \
+    "subagent_review_required" \
+    "post_integration_verify_summary.status" \
+    "reused"
+  assert_patterns "$mode_root/.agents/guides/code-review.md" \
+    "Review Policy" \
+    "main-agent-self-review" \
+    "subagent" \
+    "blocking_findings" \
+    "对抗式自审"
+done
+
+while IFS= read -r rel; do
+  [[ -n "$rel" ]] || continue
+  rg -qx "Mode: full" "$full_root/$rel" \
+    || fail "full extension missing mode marker: $rel"
+  rg -qx "Mode: placeholder" "$placeholder_root/$rel" \
+    || fail "placeholder extension missing mode marker: $rel"
+done <<<"$full_files"
+
+assert_patterns "$full_root/.agents/prompts/orchestrator-thread.md" \
+  "goal-orchestration" \
+  "write_lease" \
+  "Current State" \
+  "Thread Status" \
+  "post-integration verify" \
+  "waiting_on_child" \
+  "【完成】"
+
+assert_patterns "$full_root/.agents/prompts/issue-standard-workflow.md" \
+  "真实入口与触发" \
+  "输入装配与边界校验" \
+  "组件职责与代码落点" \
+  "关键执行时序" \
+  "停止 / 错误 / 恢复" \
+  "不要用 harness 控制流图替代业务实现图" \
+  "不要只画图，不写步骤化时序" \
+  "不要只写职责，不写代码落点" \
+  "不要只写 happy path，不写关键分支 / 降级路径" \
+  "不要把 Concrete Steps 写成纯控制面收口步骤" \
+  "write_lease" \
+  "post-integration verify"
+
+assert_patterns "$full_root/.agents/prompts/maintenance-loop.md" \
+  "report-only" \
+  "issue-create" \
+  "safe-fix" \
+  "rule-promotion" \
+  "Maintenance Findings" \
+  "Classification" \
+  "Verification Plan" \
+  "Writeback Plan" \
+  "Residual Risks" \
+  "Next Action" \
+  "rule_promotion_candidate" \
+  "human_decision_required"
+
+tmp_root="$(mktemp -d -t harness-source-verify)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+valid_plan="$template_root/.agents/plans/EXAMPLE-implementation.md"
+bash "$template_root/scripts/harness/review_gate.sh" --plan "$valid_plan" >/dev/null \
+  || fail "review gate rejected the source exemplar"
+(
+  cd "$template_root"
+  make harness-review-gate PLAN="$valid_plan" >/dev/null
+) || fail "Makefile review gate rejected the source exemplar"
+
+legacy_plan="$tmp_root/legacy-plan.md"
+bad_blocking="$tmp_root/bad-blocking.md"
+bad_steps="$tmp_root/bad-steps.md"
+bad_core="$tmp_root/bad-core.md"
+bad_branch="$tmp_root/bad-branch.md"
+bad_snippets="$tmp_root/bad-snippets.md"
+bad_component="$tmp_root/bad-component.md"
+bad_harness_flow="$tmp_root/bad-harness-flow.md"
+
+cp "$valid_plan" "$bad_blocking"
+cp "$valid_plan" "$bad_steps"
+cp "$valid_plan" "$bad_core"
+cp "$valid_plan" "$bad_branch"
+cp "$valid_plan" "$bad_snippets"
+cp "$valid_plan" "$bad_component"
+cp "$valid_plan" "$legacy_plan"
+
+perl -0pi -e 's/## 0\. 现有架构回顾与核心设计决策/## Architecture \/ Data Flow/' "$legacy_plan"
+bash "$template_root/scripts/harness/review_gate.sh" --plan "$legacy_plan" >/dev/null \
+  || fail "review gate rejected the legacy implementation section"
+
+perl -0pi -e 's/`blocking_findings`: none/`blocking_findings`: correctness regression/' "$bad_blocking"
+perl -0pi -e 's/步骤化时序/执行顺序/g' "$bad_steps"
+perl -0pi -e 's/装配结果 \/ 核心对象/装配产物/g' "$bad_core"
+perl -0pi -e 's/关键分支 \/ 降级路径/异常分支/g' "$bad_branch"
+perl -0pi -e 's/## Reference Snippets/## Reference Samples/' "$bad_snippets"
+python3 - "$bad_component" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+start = text.index("### 组件职责与代码落点")
+end = text.index("### 关键执行时序", start)
+section = text[start:end]
+lines = section.splitlines()
+kept = [line for line in lines if not (line.startswith("|") and "---" not in line and "模块/类型" not in line)]
+path.write_text(text[:start] + "\n".join(kept) + "\n\n" + text[end:])
+PY
+
+cat >"$bad_harness_flow" <<'EOF'
+# ExecPlan: harness-only flow
+
+## Architecture / Data Flow
+
+```mermaid
+flowchart TD
+  Collect["collect"] --> Verify["verify"]
+  Verify --> Review["review"]
+```
+
+## Reference Snippets
+
+```text
+result=pass
+```
+
+## Concrete Steps
+
+### 实现步骤
+1. 运行控制面。
+
+## Review Summary
+- `blocking_findings`: none
+EOF
+
+assert_plan_rejected "$bad_blocking" "blocking finding"
+assert_plan_rejected "$bad_steps" "missing step-by-step sequence"
+assert_plan_rejected "$bad_core" "missing assembled core object"
+assert_plan_rejected "$bad_branch" "missing key branch"
+assert_plan_rejected "$bad_snippets" "missing reference snippets"
+assert_plan_rejected "$bad_component" "missing component responsibility row"
+assert_plan_rejected "$bad_harness_flow" "harness-only flow"
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHONDONTWRITEBYTECODE=1 python3 "$template_root/.agents/skills/project-plan-archive/tests/test_project_plan_archive.py" >/dev/null
+  PYTHONDONTWRITEBYTECODE=1 python3 "$template_root/.agents/skills/project-version-release/scripts/project_version_release.py" --help >/dev/null
+else
+  fail "python3 is required for harness source verification"
+fi
+
+bash -n \
+  "$repo_root/scripts/init_harness_project.sh" \
+  "$repo_root/scripts/verify_harness_source.sh" \
+  "$template_root/scripts/harness/check.sh" \
+  "$template_root/scripts/harness/common.sh" \
+  "$template_root/scripts/harness/review_gate.sh" \
+  "$template_root/scripts/harness/evidence.sh"
+
+init_target="$tmp_root/initialized-target"
+bash "$repo_root/scripts/init_harness_project.sh" \
+  --target "$tmp_root/dry-run-target" \
+  --project-name "Harness Source Verify" \
+  --stack go \
+  --provider neutral \
+  --issue-provider linear \
+  --issue-prefix HSV \
+  --dry-run >/dev/null
+bash "$repo_root/scripts/init_harness_project.sh" \
+  --target "$init_target" \
+  --project-name "Harness Source Verify" \
+  --stack go \
+  --provider neutral \
+  --issue-provider linear \
+  --issue-prefix HSV >/dev/null
+
+(
+  cd "$init_target"
+  [[ -f scripts/harness/evidence.sh ]] \
+    || fail "initialized target is missing Bash evidence helper"
+  [[ -f scripts/harness/evidence.ps1 ]] \
+    || fail "initialized target is missing PowerShell evidence helper"
+  bash scripts/harness/check.sh >/dev/null
+)
+
+if command -v pwsh >/dev/null 2>&1; then
+  pwsh -NoProfile -File "$repo_root/scripts/verify_harness_source.ps1" >/dev/null
+  echo "PowerShell source verify: passed with pwsh"
+elif command -v powershell >/dev/null 2>&1; then
+  powershell -NoProfile -File "$repo_root/scripts/verify_harness_source.ps1" >/dev/null
+  echo "PowerShell source verify: passed with powershell"
+else
+  echo "PowerShell source verify: runtime unavailable; static parity checks passed"
+fi
+
+if [[ "${HARNESS_SOURCE_SKIP_EXTERNAL_TESTS:-0}" != "1" && -d "$repo_root/tests" ]]; then
+  bash "$repo_root/tests/evidence_helper_test.sh"
+  bash "$repo_root/tests/target_check_contract_test.sh"
+  bash "$repo_root/tests/policy_contract_test.sh"
+fi
+
+echo "harness source verify passed"

--- a/sources/agent_extensions/full/.agents/guides/code-review.md
+++ b/sources/agent_extensions/full/.agents/guides/code-review.md
@@ -102,3 +102,11 @@ Residual Risks 与下一步建议；
 - 发现范围膨胀时，优先判为 scope finding，而不是顺手扩大任务。
 - 外部 review 或工具 finding 需要折回本文件的输出结构。
 - 非阻塞建议只能进入 follow-up，不得阻塞当前冻结范围。
+
+## 9. Review Policy
+
+- `standard`：`review_owner=main-agent-self-review`，主 agent 必须切换到对抗式自审，按正确性、回归风险、范围越界、测试缺口、可维护性顺序 findings-first 输出。
+- `strict`：`review_owner=subagent`，必须由未实施该改动的 subagent 独立评审；不可用时停止在 `blocked: subagent_review_unavailable`。
+- 两种 policy 都必须输出 `blocking_findings`，且只有 `blocking_findings=none` 才能通过 review checkpoint。
+- 用户显式要求独立评审、多仓 / 多 lease / 集成、安全 / contract、schema / 数据、并发 / 幂等 / 重试 / 状态机、release / 生产 / 不可逆副作用、required live E2E、full-auto、自动 merge 或风险未知时必须 strict。
+- 未提供 `review_policy` 的旧调用按 strict 处理。

--- a/sources/agent_extensions/full/.agents/prompts/issue-standard-workflow.md
+++ b/sources/agent_extensions/full/.agents/prompts/issue-standard-workflow.md
@@ -489,3 +489,13 @@ Constraints: <CONSTRAINTS>
 - 需要交互式 loop 入口时，优先改用 `.agents/prompts/loop-codex.md`。
 - 需要无人值守 / 自动推进时，优先改用 `.agents/prompts/loop-automation.md`。
 - 做本地 review 前，默认先读取 `.agents/guides/code-review.md`（若存在）。
+
+## 4. 自适应 Review 与验证证据复用
+
+- 在 gate / freeze 阶段派生 `review_policy=standard|strict`，同时写入 `subagent_review_required`。
+- `standard` 可由主 agent 做 findings-first 对抗式自审；`strict` 必须由 subagent 独立评审。两者都以 `blocking_findings=none` 收口。
+- 多仓、多可写 lease、branch / worktree 集成、安全或公开 contract、schema / 数据、并发 / 幂等 / 重试 / 业务状态机、release / 生产 / 不可逆副作用、required live E2E、full-auto、自动 merge 或风险未知时使用 `strict`。
+- 未提供 `review_policy` 的旧调用按 `strict` 处理。
+- 验证后记录 `evidence_id`、有序命令和结果、`execution_session_id`、验证类型、时间与仓库路径。验证类型为 `deterministic-local`、`environment-dependent` 或 `live`。
+- 只有同一 session、同一快照、同一命令顺序的单仓单写入者 `deterministic-local` 证据才可在 post-integration verify 标记为 `reused`；strict、环境依赖、live、多仓、多 lease 或任何不确定情况都重跑。
+- required live E2E 不可复用，未执行时继续停在既有 manual gate。

--- a/sources/agent_extensions/full/.agents/prompts/loop-automation.md
+++ b/sources/agent_extensions/full/.agents/prompts/loop-automation.md
@@ -185,3 +185,11 @@ collect -> gate -> freeze -> slice -> dispatch -> implement -> verify -> review 
 - 只想冻结 inventory 时用 `create-issues`。
 - 不想自动收尾时用 `implement-no-merge`。
 - 只有确认 merge gate、权限、验证和 writeback 都稳定后，才使用 `full-auto`。
+
+## 8. Review Policy 与 Evidence 安全边界
+
+- automation 必须在 gate / freeze 写入 `review_policy`；兼容性默认 `strict`，只有新版 Goal Prompt 完成风险派生后才可显式选择 standard。
+- `subagent_review_required = review_policy == strict`。strict 下 subagent 不可用时停止，不允许静默降级成主 agent 自审。
+- required live E2E、full-auto 和自动 merge 本身都触发 strict；多仓、多 lease、集成、安全、contract、schema / 数据、并发 / 幂等 / 重试、release / 生产或未知风险同样触发 strict。
+- `verification_summary` 必须记录 `evidence_id`、命令顺序、session 和验证类型。
+- 仅同 session、同快照、同命令的单仓单写入者 deterministic-local 证据可复用；任何无法确认的情况默认重跑。

--- a/sources/agent_extensions/full/.agents/prompts/loop-codex.md
+++ b/sources/agent_extensions/full/.agents/prompts/loop-codex.md
@@ -210,3 +210,11 @@ repo truth -> external current truth -> diff -> update/create -> readback verify
 - 自动推进、run id、drain 策略等语义读 `loop-automation.md`。
 - review 前默认读 `.agents/guides/code-review.md`。
 - lint 或机械规则接入前默认读 `.agents/guides/linter.md` 和 `docs/harness/project-constraints.md`。
+
+## 6. 自适应 Review / Evidence Loop
+
+- gate / freeze 先写入 `review_policy` 与 `subagent_review_required`。普通单仓低风险任务可显式使用 standard 对抗式自审；strict 必须由 subagent 独立评审，旧调用未提供 policy 时按 strict。
+- strict 覆盖多仓 / 多 lease / 集成、安全与公开 contract、schema / 数据、并发 / 幂等 / 重试 / 业务状态机、release / 生产 / 不可逆副作用、required live E2E、full-auto、自动 merge和未知风险。
+- verify 成功后记录 `evidence_id`、有序命令、`execution_session_id` 和验证类型。
+- post-integration verify 仍必须进入；只允许同一执行 session、同一快照、同一命令顺序、单仓单写入者的 deterministic-local 结果复用。
+- strict、环境依赖、live、多仓、多 lease、发生 integration event 或尚有 required live E2E 时必须重跑。

--- a/sources/agent_extensions/full/.agents/prompts/orchestrator-thread.md
+++ b/sources/agent_extensions/full/.agents/prompts/orchestrator-thread.md
@@ -201,3 +201,14 @@ When Done:
 - `set_thread_title` 用于对齐 `<issue-id> <role> [short-scope]` 和完成后的 `【完成】` 标识。
 - 不默认使用 `set_thread_archived`；归档必须由用户显式要求。
 - thread tools 不可用时，使用人工 handoff，但仍保留 `Current State`、`Thread Status`、`write_lease` 和 recovery fields。
+
+## 6. Review / Evidence 编排字段
+
+主 thread 在 gate / freeze 记录：
+
+- `review_policy`: `standard` / `strict`
+- `subagent_review_required`: `true` / `false`
+
+多仓、多个可写 lease、branch / worktree 集成会自动触发 strict，因此这些场景不得复用 pre-integration 验证。其余 strict 风险条件沿用 `docs/harness/control-plane.md`。
+
+每个验证结果记录 `evidence_id`、有序命令、`execution_session_id` 和验证类型。只有单仓、单写入者、同 session、未发生任何 integration event 且 deterministic-local 的证据可在阶段内复用；复用时仍进入 post-integration verify，并写 `post_integration_verify_summary.status = reused` 与对应 evidence id。多仓、多 lease、strict、环境依赖、live 或不确定时重跑。

--- a/sources/agent_extensions/placeholder/.agents/guides/code-review.md
+++ b/sources/agent_extensions/placeholder/.agents/guides/code-review.md
@@ -30,3 +30,10 @@ Mode: placeholder
 - 若仓库已有 `Review Summary` 字段契约，应以后者为准
 - 若 Superpowers skills 可用，只能参考 `.agents/prompts/README.md` 的 Optional Superpowers Skill Hooks；当前占位文件不冻结完整 review skill hook contract
 - 补齐前不要把当前文件当作完整 review gate contract
+
+## 基础 Review Policy
+
+- standard 使用 `review_owner=main-agent-self-review`，要求主 agent 做 findings-first 对抗式自审。
+- strict 使用 `review_owner=subagent`，必须由 subagent 独立评审；不可用时阻塞。
+- 两种 policy 都必须输出 `blocking_findings`，只有 `blocking_findings=none` 才通过。
+- 未提供 `review_policy` 时按 strict；repo-local 规则只能增加 strict 条件，不能降低 `docs/harness/control-plane.md` 的基础风险条件。

--- a/sources/agent_extensions/placeholder/.agents/prompts/issue-standard-workflow.md
+++ b/sources/agent_extensions/placeholder/.agents/prompts/issue-standard-workflow.md
@@ -104,3 +104,12 @@ Repo-local TODO: 合并动作、Linear/Issue writeback、ChangeLog 规则。
 - plan-only 输出即使来自占位 prompt，也不能退化成纯 harness 流程；仍要按 `.agents/PLANS.md` 写清实现逻辑骨架
 - 若 Superpowers skills 可用，只能参考 `.agents/prompts/README.md` 的 Optional Superpowers Skill Hooks；当前占位文件不冻结完整 skill hook contract
 - 当前文件只是占位 skeleton，补齐前不要把它当成可直接执行的完整仓库 contract
+
+## 基础 Review / Evidence Contract
+
+即使本文件仍是 placeholder，也必须继承 `docs/harness/control-plane.md` 的基础 contract：
+
+- gate / freeze 派生 `review_policy=standard|strict` 和 `subagent_review_required`；未提供 policy 时兼容性默认 `strict`。
+- `standard` 允许主 agent 对抗式自审；`strict` 必须由 subagent 独立评审，均要求 `blocking_findings=none`。
+- 验证摘要记录 `evidence_id`、同一执行 session、有序命令与 `deterministic-local` / `environment-dependent` / `live` 类型。
+- 只有同 session、同快照、同命令的确定性本地证据才可在 post-integration verify 标记 `reused`；strict、live、环境依赖、多仓、多 lease 或任何不确定情况必须重跑。

--- a/sources/agent_extensions/placeholder/.agents/prompts/loop-automation.md
+++ b/sources/agent_extensions/placeholder/.agents/prompts/loop-automation.md
@@ -55,3 +55,10 @@ Repo-local TODO:
 - 补齐后默认由 agent 给出 `merge / escalation` 结论
 - 若 Superpowers skills 可用，只能参考 `.agents/prompts/README.md` 的 Optional Superpowers Skill Hooks；当前占位文件不冻结完整 automation skill hook contract
 - 补齐前不要把这里的占位语义当作完整 automation contract
+
+## 基础 Review / Evidence 安全边界
+
+- gate / freeze 派生 `review_policy` 和 `subagent_review_required`；兼容性默认 `strict`。
+- standard 允许主 agent 对抗式自审；strict 必须由 subagent 独立评审。
+- `verification_summary` 记录 `evidence_id`、有序命令、session 与验证类型。
+- 只有单仓单写入者的 deterministic-local 同 session / 同快照 / 同命令证据可复用；strict、live、环境依赖、多仓、多 lease 或任何无法确认的情况默认重跑。

--- a/sources/agent_extensions/placeholder/.agents/prompts/loop-codex.md
+++ b/sources/agent_extensions/placeholder/.agents/prompts/loop-codex.md
@@ -63,3 +63,11 @@ Repo-local TODO: goal_unit_roster、write_lease、waiting_on_child、post-integr
 - 若涉及多 thread / worktree / subagent 编排，应优先补齐 `.agents/prompts/orchestrator-thread.md`
 - 补齐后默认应把当前状态、`recovery_point`、`next_action` 写回 Linear
 - 补齐前不要把这里的占位语义当作完整 loop contract
+
+## 基础 Review / Evidence Loop
+
+- gate / freeze 派生 `review_policy` 与 `subagent_review_required`；未提供 policy 时按 strict。
+- standard 允许主 agent findings-first 对抗式自审，strict 必须由 subagent 独立评审。
+- verify 摘要必须含 `evidence_id`、有序命令、同一执行 session 和验证类型。
+- post-integration verify 不跳过；只有同 session / 同快照 / 同命令的 deterministic-local 证据可复用。
+- 多仓、多 lease、strict、环境依赖、live 或仍有 required live E2E 时必须重跑。

--- a/sources/agent_extensions/placeholder/.agents/prompts/orchestrator-thread.md
+++ b/sources/agent_extensions/placeholder/.agents/prompts/orchestrator-thread.md
@@ -52,3 +52,10 @@ When child thread is done:
 - 可写 thread 必须有 `write_lease`
 - 子 thread 不自行 merge，不自行扩大范围
 - post-integration verify 仍由主 thread 基于最终 repo truth 执行
+
+## 基础 Review / Evidence 编排字段
+
+- gate / freeze 记录 `review_policy` 与 `subagent_review_required`。
+- 多仓、多个可写 lease、branch / worktree 集成自动使用 strict，并重新执行验证。
+- 验证摘要记录 `evidence_id`、有序命令、session 与验证类型。
+- 仅单仓单写入者、同 session、无 integration event 的 deterministic-local 证据可在 post-integration verify 标记 `post_integration_verify_summary.status = reused`；strict、live、环境依赖或不确定时重跑。

--- a/template/.agents/skills/issue-goal-prompt/SKILL.md
+++ b/template/.agents/skills/issue-goal-prompt/SKILL.md
@@ -45,16 +45,20 @@ description: 从任务系统条目生成可执行目标提示词，适用于 har
    - 分支名只允许 ASCII 字母、数字、`-`、`_` 和 `/`。
    - 保护已有脏工作区；不得丢弃或覆盖无关改动。
    - 在计划、恢复点和最终回写中记录实际分支名。
-5. 要求验证后执行独立评审：
-   - 可用时优先使用 subagent 评审。
-   - 对实现任务，主 agent 自审不能单独满足默认评审门禁。
-   - 如果必需的 subagent 评审不可用，停止在 `blocked: subagent_review_unavailable`。
+5. 在 `gate / freeze` 阶段派生 `review_policy`，并写入 Goal Prompt 与 Goal 状态文件：
+   - 用户显式要求独立评审时使用 `strict`。
+   - 多仓 / 多可写 lease / branch 或 worktree 集成、鉴权安全权限、公开 API / contract、schema / migration / 数据修改、并发 / 幂等 / 重试 / 业务状态机、release / 部署 / 生产或不可逆副作用、required live E2E、full-auto、自动 merge，以及风险无法可靠判断时使用 `strict`。
+   - 其余普通单仓任务可显式使用 `standard`；`standard` 允许主 agent 做 findings-first 对抗式自审。
+   - 兼容性默认值是 `strict`：调用方未提供 policy 时不得自行降为 `standard`。
+   - `subagent_review_required` 等于 `review_policy == strict`。`strict` 下必须由 subagent 独立评审；不可用时停止在 `blocked: subagent_review_unavailable`。
+   - 两种 policy 都必须满足 `blocking_findings=none`，并在回写中记录 `review_owner`。
 6. 编码 live E2E 策略：
    - 默认目标是 `pre-commit ready`。
    - 除非用户明确要求，不要 commit、push、merge 或 mark Done。
    - 如果 live E2E 必需但当前不可用，在本地验证后停止在 `manual_gate_live_e2e`。
    - 如果 live E2E 不适用，设置 `live_e2e_status: not_required`。
-7. 加入任务系统回写要求：验证、评审、集成、集成后验证、live E2E 状态、残余风险、恢复点和下一步。
+7. 编码验证证据复用规则：用 evidence helper 记录仓库快照、有序命令、执行 session、验证类型、时间和仓库路径；仅允许同 session、同快照、同命令的单仓单写入者 `deterministic-local` 证据复用。多仓、多 lease、strict、环境依赖、live 或任何不确定情况都重跑。
+8. 加入任务系统回写要求：验证、评审、集成、集成后验证、验证证据复用、live E2E 状态、残余风险、恢复点和下一步。
 
 完整提示词、状态文件和短启动提示词模板见 `references/goal-prompt-template.md`。
 

--- a/template/.agents/skills/issue-goal-prompt/references/goal-prompt-template.md
+++ b/template/.agents/skills/issue-goal-prompt/references/goal-prompt-template.md
@@ -14,6 +14,8 @@
 当前模式：
 - issue_provider: <linear|github|gitlab|repo|other>
 - mode: <propose-only|plan-only|create-issues|implement-no-merge|full-auto>
+- review_policy: <standard|strict>
+- subagent_review_required: <true|false>
 - default_boundary: pre-commit ready，除非用户明确要求 commit / push / merge / Done
 
 分支要求：
@@ -85,10 +87,13 @@ Harness 要求：
 - 不保存真实凭据、token、Cookie、完整 URL、真实数据库主机、真实 SQL 或其它敏感输出到提交版文档。
 
 评审要求：
-- 验证通过后，必须执行独立评审。
-- 默认 `review_owner: subagent`。
-- 主 agent 自审不能满足默认评审门禁。
-- 如果 subagent 工具不可用且评审为必需项，停止在 `blocked: subagent_review_unavailable`，写明 `next_action`。
+- 在 gate / freeze 阶段根据冻结范围派生 `review_policy`；用户显式要求独立评审时无条件使用 `strict`。
+- 多仓 / 多可写 lease / branch 或 worktree 集成、鉴权安全权限、公开 API / contract、schema / migration / 数据修改、并发 / 幂等 / 重试 / 业务状态机、release / 部署 / 生产或不可逆副作用、required live E2E、full-auto、自动 merge，以及风险无法可靠判断时必须使用 `strict`。
+- 调用方未提供 `review_policy` 时使用兼容性默认 `strict`；只有本提示词完成风险派生并确认不命中 strict 条件时，才可显式使用 `standard`。
+- `standard` 允许主 agent 执行 findings-first 对抗式自审，回写 `review_owner: main-agent-self-review`。
+- `strict` 必须由 subagent 独立评审，回写 `review_owner: subagent`；subagent 不可用时停止在 `blocked: subagent_review_unavailable`，写明 `next_action`。
+- `subagent_review_required` 等于 `review_policy == strict`。
+- 两种 policy 都必须满足 `blocking_findings=none`。
 - 如果有阻塞发现，先修复，再重新执行验证 -> 评审。
 
 Live E2E 要求：
@@ -102,10 +107,17 @@ Live E2E 要求：
 - <命令 2>
 - <命令 3>
 
+验证证据与复用：
+- 成功验证后的 `verification_summary` 必须记录 `evidence_id`、Required Verification Commands 的有序命令和结果、`execution_session_id`、验证类型、执行时间和仓库路径。
+- 验证类型只能是 `deterministic-local` / `environment-dependent` / `live`。
+- 仅当单仓、单写入者、无 branch merge / rebase / cherry-pick / 冲突处理 / integration fix、当前 `evidence_id` 和命令顺序完全一致、`execution_session_id` 未变化、证据均为 `deterministic-local`，且没有未执行的 required live E2E 时，才可在 post-integration verify 复用。
+- 多仓、多 lease、`review_policy=strict`、`environment-dependent`、`live` 或任何无法确认的情况一律重跑。
+- 复用时仍进入 post-integration verify，并记录 `post_integration_verify_summary.status`: `reused` 与对应 `evidence_id`。
+
 任务系统回写：
 完成或阻塞时，给任务 <ISSUE-ID> 追加评论，或写入仓库任务回写日志，至少包含：
 - verification_summary
-- review_summary，其中明确 `review_owner`
+- review_summary，其中明确 `review_policy`、`subagent_review_required`、`review_owner`
 - integration_summary
 - post_integration_verify_summary
 - writeback_summary
@@ -146,7 +158,8 @@ Live E2E 要求：
 - `goal_state`: ready_to_execute
 - `prompt_length`: <字符数>
 - `plan_required`: true
-- `subagent_review_required`: true
+- `review_policy`: <standard|strict>
+- `subagent_review_required`: <true|false>
 - `live_e2e_policy`: required_if_available_else_manual_gate
 - `pre_commit_boundary`: true
 - `branch_required`: true

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -33,6 +33,7 @@
 | 可选主 thread 编排 Prompt | `.agents/prompts/orchestrator-thread.md`（如存在） |
 | 可选维护循环 Prompt | `.agents/prompts/maintenance-loop.md`（如存在，默认 `report-only`） |
 | 可选 Guide 层 | `.agents/guides/`（如存在） |
+| 验证证据快照 | `scripts/harness/evidence.sh` / `scripts/harness/evidence.ps1` |
 
 ## 真相边界
 
@@ -59,6 +60,8 @@
 - 复杂任务默认先写 plan，再进入实现
 - macOS / Linux / Git Bash 默认用 `make harness-verify` 验证 base harness
 - Windows PowerShell 默认用 `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\harness\check.ps1` 验证 base harness
+- `make harness-verify` 只验证 base harness 运行时关键不变量，不替代项目自身 build / test / lint
+- 成功验证后可用 `bash scripts/harness/evidence.sh snapshot` 生成只读快照；是否复用仍按 `docs/harness/control-plane.md` 的 session、命令顺序、验证类型和 `review_policy` 规则判断
 - Bash / Git Bash 命令示例使用 POSIX 路径；PowerShell 命令示例使用 `C:\path\to\repo` 或 UNC 路径，不自动互转
 - `docs/harness/*.md` 默认应提交
 - 初始化后应在 `docs/harness/project-constraints.md` 中登记项目级机械约束；没有可执行命令或 gate 的规则不得标记为 `enforced`

--- a/template/README.md
+++ b/template/README.md
@@ -8,7 +8,7 @@
 - 控制面文档统一收口到 `docs/harness/`
 - 初始化后应先确认 `.gitignore`、`.agents/`、`docs/harness/project-constraints.md`、`docs/test/RUNBOOK_TEMPLATE.md`、`scripts/harness/` 是否就位并可执行
 - 若通过 agent 驱动初始化，默认再补齐完整 `full` 版 `.agents/prompts/` 与 `.agents/guides/`
-- base harness 默认带 Bash 与 PowerShell 两套 `check + review_gate`，以及 `.agents/skills/` repo-local workflow 层
+- base harness 默认带 Bash 与 PowerShell 两套 `check + review_gate + evidence`，以及 `.agents/skills/` repo-local workflow 层
 - `.agents/state/` 与 `.agents/runs/` 默认作为本地辅助运行面存在
 
 ## 推荐阅读顺序
@@ -41,6 +41,8 @@
 | `.agents/` | 计划协议、计划模板、实现型 exemplar、默认 workflow skill、本地辅助运行面，以及后续 prompts / guides |
 | `scripts/harness/` | base harness 的最小 gate 脚本与共享 helper |
 
+`make harness-check` / `make harness-verify` 是目标仓日常检查，只验证 harness 运行时关键不变量，不替代项目自身 build / test / lint。需要记录可复用验证证据时，在仓库根执行 `bash scripts/harness/evidence.sh snapshot`；PowerShell 使用 `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\harness\evidence.ps1 -Action Snapshot`。
+
 ## 默认 truth split
 
 - `Issue Tracker = 主协作真相`
@@ -70,3 +72,4 @@
 12. 若存在 `.agents/prompts/maintenance-loop.md`，确认默认 mode 是 `report-only`
 13. macOS / Linux / Git Bash 执行 `make harness-verify`
 14. Windows PowerShell 执行 `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\harness\check.ps1`
+15. 验证成功后按控制面 contract 记录 evidence snapshot、有序命令、执行 session 和验证类型

--- a/template/docs/harness/control-plane.md
+++ b/template/docs/harness/control-plane.md
@@ -208,8 +208,43 @@
 - 默认顺序是 `implement -> local/test verify -> review -> integrate -> final verify`。
 - 第一个 `verify` 是执行者或 test thread 的局部验证，用来确认输出进入可 review 状态。
 - review 默认前置；集成后若发生冲突处理、integration fix、diff 形态明显变化、二次 verify 失败后返修，或 write scope 边界有争议，主 thread 必须补轻量 review。
-- `integrate -> verify` 是权威验证。主 thread 集成任何可写 lease 后，必须在集成后的 repo truth 上重新跑最终验证矩阵。
+- `integrate -> verify` 是权威验证。post-integration verify 阶段不得跳过；只有满足下方 Verification Evidence Reuse Contract 时，阶段内的确定性本地命令才可记录为证据复用，否则必须在集成后的 repo truth 上重新执行最终验证矩阵。
 - 若 Goal Prompt、Issue Acceptance Matrix、active plan 或 test runbook 声明 required live E2E，则 post-integration verify 必须执行 live E2E；无法执行时停止在 `blocked` / `manual-gate`，不得进入 `verified`、`ready_for_merge` 或 `done`。
+
+#### Verification Evidence Reuse Contract
+
+验证完成后，`verification_summary` 必须记录：
+
+- `evidence_id`：由 `scripts/harness/evidence.sh snapshot` 或 `scripts/harness/evidence.ps1 -Action Snapshot` 生成。
+- `commands`：Required Verification Commands 的有序命令及逐项结果，集合和顺序都是 contract。
+- `execution_session_id`：当前连续执行 session 的稳定标识；进程重启、任务交接或恢复执行后必须更换。
+- `verification_type`：`deterministic-local` / `environment-dependent` / `live`。
+- `verified_at` 与 `repository_path`。
+
+只有以下条件全部满足，post-integration verify 才可复用已有验证证据：
+
+1. 单仓、单写入者，且没有 branch merge、rebase、cherry-pick、冲突处理或 integration fix。
+2. 当前 `evidence_id` 与验证完成时记录的值完全一致，helper 同时返回 `reusable=true`。
+3. Required Verification Commands 的集合和顺序完全一致。
+4. 仍在同一执行 session，即 `execution_session_id` 完全一致。
+5. 所有待复用项都是 `deterministic-local` build / test / lint / contract check。
+6. 没有尚未执行的 required live E2E。
+
+以下情况一律重新执行：多仓、多个可写 lease、`review_policy=strict`、`environment-dependent`、`live`，以及任何发生过集成或历史改写的场景。任何无法确认的情况默认重跑。
+
+复用不改变状态机：仍进入 post-integration verify，并写入：
+
+```text
+post_integration_verify_summary.status = reused
+post_integration_verify_summary.evidence_id = <id>
+```
+
+字段化记录时使用：
+
+- `post_integration_verify_summary.status`: `reused`
+- `post_integration_verify_summary.evidence_id`: `<id>`
+
+未复用时 `status=executed`，并保留新执行命令及结果。未完成的 required live E2E 永远不可由本地证据替代。
 
 ### 跨仓 truth split（按需）
 
@@ -290,6 +325,31 @@ Maintenance loop 的输出必须包含：
 - prompts / guides 与 `AGENTS.md`、`docs/harness/*`、`.agents/PLANS.md` 冲突时，以后者为准。
 
 ## Review 口径
+
+### Review Policy Contract
+
+在 `gate / freeze` 阶段基于冻结范围派生并记录：
+
+- `review_policy`: `standard` / `strict`
+- `subagent_review_required`: `review_policy == strict`
+
+兼容性规则：用户显式要求独立评审时无条件使用 `strict`；调用方未提供 `review_policy` 时按 `strict` 处理。只有新版 Goal Prompt 完成风险派生且确认不命中 strict 条件时，才可显式写入 `standard`。
+
+`standard` 允许主 agent 执行对抗式自审，但仍是独立的 review checkpoint，必须按 findings-first 输出正确性、回归风险、范围越界、测试缺口、可维护性，并满足 `blocking_findings=none`。Issue writeback 的 `review_owner` 记录为 `main-agent-self-review`。
+
+`strict` 必须由 subagent 独立评审，Issue writeback 的 `review_owner` 记录为 `subagent`。subagent 不可用时保持 `blocked: subagent_review_unavailable`，不得用主 agent 自审降级替代。
+
+以下任一条件自动进入 `strict`：
+
+- 多仓代码改动、多个可写 lease 或 branch / worktree 集成。
+- 鉴权、安全、权限、公开 API 或 contract 兼容性。
+- schema、migration 或数据修改。
+- 并发、幂等、重试或业务状态机。
+- release、部署、生产环境或不可逆外部副作用。
+- required live E2E、full-auto 或自动 merge。
+- 风险无法可靠判断。
+
+`harness-review-gate` 的接口和职责不变：继续校验完整计划骨架与 `blocking_findings`，不新增人工 checkpoint，也不自行推导 reviewer 身份。
 
 ### findings-first
 

--- a/template/scripts/harness/check.ps1
+++ b/template/scripts/harness/check.ps1
@@ -3,112 +3,69 @@ param()
 
 $ErrorActionPreference = "Stop"
 $scriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
-. (Join-Path $scriptDir "common.ps1")
-
-Set-Location -LiteralPath $Script:RepoRoot
+$repoRoot = (Resolve-Path (Join-Path $scriptDir "..\..")).Path
+Set-Location $repoRoot
 
 function Fail {
     param([Parameter(Mandatory=$true)][string]$Message)
-
     [Console]::Error.WriteLine($Message)
     exit 1
 }
 
 function Get-FileText {
     param([Parameter(Mandatory=$true)][string]$Path)
-
-    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
-        Fail "Missing required harness file: $Path"
-    }
-
-    return (Get-Content -LiteralPath $Path -Raw -Encoding UTF8)
+    return [System.IO.File]::ReadAllText((Join-Path $repoRoot $Path))
 }
 
 function Assert-FileContains {
     param(
         [Parameter(Mandatory=$true)][string]$Path,
         [Parameter(Mandatory=$true)][string]$Pattern,
-        [string]$Message
-    )
-
-    $text = Get-FileText -Path $Path
-    if ($text.IndexOf($Pattern, [System.StringComparison]::Ordinal) -lt 0) {
-        if ([string]::IsNullOrEmpty($Message)) {
-            $Message = "$Path missing required pattern: $Pattern"
-        }
-        Fail $Message
-    }
-}
-
-function Assert-AnyFileContains {
-    param(
-        [Parameter(Mandatory=$true)][string[]]$Paths,
-        [Parameter(Mandatory=$true)][string]$Pattern,
         [Parameter(Mandatory=$true)][string]$Message
     )
-
-    foreach ($path in $Paths) {
-        if ((Get-FileText -Path $path).IndexOf($Pattern, [System.StringComparison]::Ordinal) -ge 0) {
-            return
-        }
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Fail -Message "Missing required harness file: $Path"
     }
-
-    Fail $Message
-}
-
-function Assert-FileMatches {
-    param(
-        [Parameter(Mandatory=$true)][string]$Path,
-        [Parameter(Mandatory=$true)][string]$Regex,
-        [Parameter(Mandatory=$true)][string]$Message
-    )
-
-    $text = Get-FileText -Path $Path
-    if ($text -notmatch $Regex) {
-        Fail $Message
+    if (-not (Get-FileText -Path $Path).Contains($Pattern)) {
+        Fail -Message $Message
     }
 }
 
-function Test-ReviewGate {
+function Invoke-ReviewGateProcess {
     param(
         [Parameter(Mandatory=$true)][string]$Plan,
         [Parameter(Mandatory=$true)][bool]$ShouldPass,
-        [Parameter(Mandatory=$true)][string]$FailureMessage
+        [Parameter(Mandatory=$true)][string]$Message
     )
 
-    $reviewGate = Join-Path $Script:RepoRoot "scripts\harness\review_gate.ps1"
-    $psCommand = if ($PSVersionTable.PSEdition -eq "Core") {
-        Get-Command pwsh -ErrorAction SilentlyContinue
-    } else {
-        Get-Command powershell -ErrorAction SilentlyContinue
+    $reviewGate = Join-Path $repoRoot "scripts\harness\review_gate.ps1"
+    $powerShellExe = (Get-Process -Id $PID).Path
+    $invokeArguments = @("-NoProfile")
+    if ((Split-Path -Leaf $powerShellExe) -ieq "powershell.exe") {
+        $invokeArguments += @("-ExecutionPolicy", "Bypass")
     }
-
-    if ($null -eq $psCommand) {
-        $process = Get-Process -Id $PID
-        if ($process -and $process.Path) {
-            $exe = $process.Path
-        } else {
-            Fail "Unable to locate current PowerShell executable for review_gate.ps1 smoke test"
-        }
-    } else {
-        $exe = $psCommand.Source
-    }
-
-    $invokeArgs = @("-NoProfile")
-    if ((Split-Path -Leaf $exe) -ieq "powershell.exe") {
-        $invokeArgs += @("-ExecutionPolicy", "Bypass")
-    }
-    $invokeArgs += @("-File", $reviewGate, "-Plan", $Plan)
-
-    & $exe @invokeArgs *> $null
+    $invokeArguments += @("-File", $reviewGate, "-Plan", $Plan)
+    & $powerShellExe @invokeArguments *> $null
     $passed = ($LASTEXITCODE -eq 0)
+    if ($passed -ne $ShouldPass) {
+        Fail -Message $Message
+    }
+}
 
-    if ($ShouldPass -and -not $passed) {
-        Fail $FailureMessage
+function Get-OutputField {
+    param(
+        [Parameter(Mandatory=$true)][object[]]$Lines,
+        [Parameter(Mandatory=$true)][string]$Name
+    )
+
+    $prefix = "$Name="
+    foreach ($line in $Lines) {
+        $text = [string]$line
+        if ($text.StartsWith($prefix, [System.StringComparison]::Ordinal)) {
+            return $text.Substring($prefix.Length)
+        }
     }
-    if (-not $ShouldPass -and $passed) {
-        Fail $FailureMessage
-    }
+    return ""
 }
 
 $requiredFiles = @(
@@ -143,416 +100,118 @@ $requiredFiles = @(
     "scripts/harness/check.sh",
     "scripts/harness/common.sh",
     "scripts/harness/review_gate.sh",
+    "scripts/harness/evidence.sh",
     "scripts/harness/check.ps1",
     "scripts/harness/common.ps1",
-    "scripts/harness/review_gate.ps1"
+    "scripts/harness/review_gate.ps1",
+    "scripts/harness/evidence.ps1"
 )
 
 foreach ($path in $requiredFiles) {
     if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
-        Fail "Missing required harness file: $path"
+        Fail -Message "Missing required harness file: $path"
     }
 }
 
-foreach ($item in @(
+if (Test-Path -LiteralPath "docs/harness/prompt-templates.md" -PathType Leaf) {
+    Fail -Message "Obsolete harness file should not exist anymore: docs/harness/prompt-templates.md"
+}
+
+$skillFrontmatter = @(
     @(".agents/skills/issue-goal-prompt/SKILL.md", "name: issue-goal-prompt"),
     @(".agents/skills/project-plan-archive/SKILL.md", "name: project-plan-archive"),
     @(".agents/skills/project-version-release/SKILL.md", "name: project-version-release"),
     @(".agents/skills/test-runbook/SKILL.md", "name: test-runbook")
-)) {
+)
+
+foreach ($item in $skillFrontmatter) {
     Assert-FileContains -Path $item[0] -Pattern "---" -Message "Skill frontmatter is incomplete: $($item[0])"
     Assert-FileContains -Path $item[0] -Pattern $item[1] -Message "Skill frontmatter is incomplete: $($item[0])"
     Assert-FileContains -Path $item[0] -Pattern "description:" -Message "Skill frontmatter is incomplete: $($item[0])"
 }
 
-foreach ($item in @(
-    @(".agents/skills/issue-goal-prompt/SKILL.md", "任务系统"),
-    @(".agents/skills/issue-goal-prompt/SKILL.md", "状态文件规则"),
-    @(".agents/skills/issue-goal-prompt/SKILL.md", "pre-commit ready"),
-    @(".agents/skills/issue-goal-prompt/SKILL.md", "subagent_review_unavailable"),
-    @(".agents/skills/issue-goal-prompt/SKILL.md", "manual_gate_live_e2e"),
-    @(".agents/skills/issue-goal-prompt/references/goal-prompt-template.md", "完整目标提示词"),
-    @(".agents/skills/issue-goal-prompt/references/goal-prompt-template.md", "状态文件模板"),
-    @(".agents/skills/issue-goal-prompt/references/goal-prompt-template.md", "短启动提示词"),
-    @(".agents/skills/project-plan-archive/SKILL.md", "先查 Issue Tracker，再归档"),
-    @(".agents/skills/project-plan-archive/SKILL.md", "--done-issue"),
-    @(".agents/skills/project-plan-archive/SKILL.md", "no_issue_default_archive"),
-    @(".agents/skills/project-plan-archive/scripts/project_plan_archive.py", "Project plan archive helper"),
-    @(".agents/skills/project-plan-archive/scripts/project_plan_archive.py", "--write"),
-    @(".agents/skills/project-version-release/SKILL.md", "issue 是执行粒度，release 是发布粒度"),
-    @(".agents/skills/project-version-release/SKILL.md", "CHANGELOG.md -> Unreleased"),
-    @(".agents/skills/project-version-release/scripts/project_version_release.py", "Project version/release helper"),
-    @(".agents/skills/project-version-release/references/project-version-policy.md", "Project Version Policy"),
-    @(".agents/skills/test-runbook/SKILL.md", "执行副作用"),
-    @(".agents/skills/test-runbook/SKILL.md", "Request / Response 回写规则"),
-    @(".agents/skills/test-runbook/SKILL.md", "提交版证据边界"),
-    @(".agents/skills/test-runbook/SKILL.md", "结果回写规则")
-)) {
-    Assert-FileContains -Path $item[0] -Pattern $item[1] -Message "$($item[0]) missing required skill pattern: $($item[1])"
-}
-
-$skillText = Get-ChildItem -Path ".agents/skills" -Recurse -File | ForEach-Object {
-    Get-Content -LiteralPath $_.FullName -Raw -Encoding UTF8
-}
-if (($skillText -join "`n") -match 'DBBridge|db_bridge_test|/Users/suqing|TEA-') {
-    Fail "Default harness skills must not contain DBBridge-specific constants"
+$projectSpecific = Get-ChildItem -LiteralPath ".agents/skills" -Recurse -File -Force |
+    Select-String -Pattern "DBBridge|db_bridge_test|/Users/suqing|TEA-" -CaseSensitive
+if ($projectSpecific) {
+    Fail -Message "Default harness skills must not contain project-specific constants"
 }
 
 $python = Get-Command python3 -ErrorAction SilentlyContinue
-if ($null -ne $python) {
-    & $python.Source ".agents/skills/project-plan-archive/scripts/project_plan_archive.py" "--help" *> $null
-    if ($LASTEXITCODE -ne 0) {
-        Fail "project_plan_archive.py --help failed"
-    }
-    & $python.Source ".agents/skills/project-version-release/scripts/project_version_release.py" "--help" *> $null
-    if ($LASTEXITCODE -ne 0) {
-        Fail "project_version_release.py --help failed"
-    }
+if ($python) {
+    & $python.Source ".agents/skills/project-plan-archive/scripts/project_plan_archive.py" --help *> $null
+    if ($LASTEXITCODE -ne 0) { Fail -Message "project_plan_archive.py --help failed" }
+    & $python.Source ".agents/skills/project-version-release/scripts/project_version_release.py" --help *> $null
+    if ($LASTEXITCODE -ne 0) { Fail -Message "project_version_release.py --help failed" }
 }
 
-if (Test-Path -LiteralPath "docs/harness/prompt-templates.md" -PathType Leaf) {
-    Fail "Obsolete harness file should not exist anymore: docs/harness/prompt-templates.md"
-}
-
+$makefileText = Get-FileText -Path "Makefile"
 foreach ($target in @("harness-check", "harness-verify", "harness-review-gate")) {
-    Assert-FileMatches -Path "Makefile" -Regex "(?m)^$([regex]::Escape($target)):" -Message "Makefile missing target: $target"
+    if ($makefileText -notmatch "(?m)^$([regex]::Escape($target)):") {
+        Fail -Message "Makefile missing target: $target"
+    }
 }
 
 foreach ($pattern in @(
-    ".DS_Store",
-    ".idea/",
-    ".vscode/",
-    "*.log",
-    "logs/",
-    "tmp/",
-    "temp/",
-    ".agents/state/*",
-    "!.agents/state/TEMPLATE.md",
-    ".agents/runs/*",
-    "!.agents/runs/TEMPLATE.md",
-    ".cursor/*",
-    "!.cursor/rules/",
-    "!.cursor/rules/*.mdc"
+    ".DS_Store", ".idea/", ".vscode/", "*.log", "logs/", "tmp/", "temp/",
+    ".agents/state/*", "!.agents/state/TEMPLATE.md", ".agents/runs/*",
+    "!.agents/runs/TEMPLATE.md", ".cursor/*", "!.cursor/rules/", "!.cursor/rules/*.mdc"
 )) {
     Assert-FileContains -Path ".gitignore" -Pattern $pattern -Message ".gitignore missing required pattern: $pattern"
 }
 
-foreach ($path in @("README.md", "AGENTS.md")) {
-    Assert-FileContains -Path $path -Pattern "EXAMPLE-implementation.md" -Message "Base harness output should point readers to EXAMPLE-implementation.md"
+$projectPlaceholder = "__PROJECT" + "_NAME__"
+$providerPlaceholder = "__PROVIDER" + "__"
+$issueProviderPlaceholder = "__ISSUE" + "_PROVIDER__"
+$issuePrefixPlaceholder = "__ISSUE" + "_PREFIX__"
+$readmeText = Get-FileText -Path "README.md"
+$controlPlaneText = Get-FileText -Path "docs/harness/control-plane.md"
+$sourceHarnessRoot = (Resolve-Path (Join-Path $repoRoot "..")).Path
+$canonicalSourceTemplate = ""
+if (Test-Path -LiteralPath (Join-Path $sourceHarnessRoot "template") -PathType Container) {
+    $canonicalSourceTemplate = (Resolve-Path (Join-Path $sourceHarnessRoot "template")).Path
 }
+$templateSource = $readmeText.Contains("# $projectPlaceholder") -and
+    $controlPlaneText.Contains($providerPlaceholder) -and
+    $controlPlaneText.Contains($issueProviderPlaceholder) -and
+    (Test-Path -LiteralPath (Join-Path $sourceHarnessRoot "scripts/verify_harness_source.sh") -PathType Leaf) -and
+    (Test-Path -LiteralPath (Join-Path $sourceHarnessRoot "scripts/verify_harness_source.ps1") -PathType Leaf) -and
+    (Test-Path -LiteralPath (Join-Path $sourceHarnessRoot "sources/agent_extensions") -PathType Container) -and
+    (-not [string]::IsNullOrWhiteSpace($canonicalSourceTemplate)) -and
+    ($repoRoot -eq $canonicalSourceTemplate)
 
-if ((Get-FileText -Path ".gitignore") -match '(?m)^docs/test') {
-    Fail ".gitignore should not ignore docs/test runbook documents"
-}
+if (-not $templateSource) {
+    $placeholderFiles = @(
+        Get-Item -LiteralPath "AGENTS.md", "README.md", "Makefile"
+        Get-ChildItem -LiteralPath "docs", ".agents" -Recurse -File -Force
+    )
+    foreach ($file in $placeholderFiles) {
+        if ($file.FullName -eq (Join-Path $repoRoot "scripts\harness\check.ps1")) { continue }
+        $text = [System.IO.File]::ReadAllText($file.FullName)
+        foreach ($placeholder in @($projectPlaceholder, $providerPlaceholder, $issueProviderPlaceholder, $issuePrefixPlaceholder)) {
+            if ($text.Contains($placeholder)) {
+                Fail -Message "Unresolved harness initializer placeholder detected"
+            }
+        }
+    }
 
-if (Test-Path -LiteralPath ".cursor/rules/harness.mdc" -PathType Leaf) {
-    foreach ($pattern in @(
-        "description: 始终使用本仓库的 harness 控制面、计划模板、测试 runbook 和验证 gate",
-        "alwaysApply: true",
-        "AGENTS.md",
-        "目录级 `AGENTS.md`",
-        "docs/harness/control-plane.md",
-        "docs/harness/issue-workflow.md",
-        "docs/harness/linear.md",
-        "docs/harness/project-constraints.md",
-        "docs/issues/README.md",
-        ".agents/PLANS.md",
-        ".agents/plans/TEMPLATE.md",
-        ".agents/plans/EXAMPLE-implementation.md",
-        "docs/test/RUNBOOK_TEMPLATE.md",
-        "make harness-verify",
-        "check.ps1"
-    )) {
-        Assert-FileContains -Path ".cursor/rules/harness.mdc" -Pattern $pattern -Message ".cursor/rules/harness.mdc missing required pattern: $pattern"
+    $mergeMatch = [regex]::Match($controlPlaneText, '当前 merge provider：\s*- `([^`]+)`')
+    $issueMatch = [regex]::Match($controlPlaneText, '当前 issue provider：\s*- `([^`]+)`')
+    $mergeProvider = if ($mergeMatch.Success) { $mergeMatch.Groups[1].Value } else { "" }
+    $issueProvider = if ($issueMatch.Success) { $issueMatch.Groups[1].Value } else { "" }
+    if ($mergeProvider -notin @("neutral", "github", "gitlab")) {
+        Fail -Message "Invalid merge provider: $mergeProvider"
+    }
+    if ($issueProvider -notin @("linear", "github", "gitlab", "repo", "other")) {
+        Fail -Message "Invalid issue provider: $issueProvider"
     }
 }
 
-foreach ($pattern in @(
-    "collect -> gate -> freeze -> slice -> dispatch -> implement -> verify -> review -> integrate -> verify -> writeback -> pr_prep -> merge -> notify",
-    "Issue Tracker 是主协作真相",
-    "repo 是主执行真相",
-    "goal-orchestration",
-    "write_lease",
-    "Current State",
-    "Thread Status",
-    "post-integration verify",
-    "waiting_on_child",
-    "【完成】",
-    "Issue Store Profiles",
-    "docs/issues/",
-    "provider 仓",
-    "consumer 仓",
-    "project-constraints.md",
-    "项目级机械约束",
-    "Maintenance Loop",
-    "report-only",
-    "rule-promotion",
-    "目录级 AGENTS",
-    ".agents/skills",
-    "运行反馈默认写回 Issue Tracker",
-    "结果回写默认写回 Issue Tracker",
-    "review_gate",
-    "check.ps1",
-    "merge",
-    "escalation",
-    ".agents/PLANS.md",
-    ".agents/plans/TEMPLATE.md"
-)) {
-    Assert-FileContains -Path "docs/harness/control-plane.md" -Pattern $pattern -Message "docs/harness/control-plane.md missing required pattern: $pattern"
+if (Test-Path -LiteralPath ".cursor/rules/harness.mdc" -PathType Leaf) {
+    Assert-FileContains -Path ".cursor/rules/harness.mdc" -Pattern "alwaysApply: true" `
+        -Message ".cursor/rules/harness.mdc missing alwaysApply: true"
+    Assert-FileContains -Path ".cursor/rules/harness.mdc" -Pattern "make harness-verify" `
+        -Message ".cursor/rules/harness.mdc missing harness verification entry"
 }
-
-foreach ($pattern in @(
-    "Issue Workflow",
-    "Issue Tracker 是主协作真相",
-    "Issue Store Profiles",
-    "Orchestration Contract",
-    "Current State Comment Contract",
-    "Thread Status Comment Contract",
-    "Write Lease Contract",
-    "Post-Integration Verify Contract",
-    "goal-orchestration",
-    "write_lease",
-    "【完成】",
-    "Requirement Clarification",
-    "Master Issue",
-    "Execution Issue",
-    "Codex Handoff",
-    "运行反馈 Comment Contract",
-    "结果回写 Contract",
-    "recovery_point",
-    "next_action",
-    "current_issue_state",
-    "Master 是否可置 Done"
-)) {
-    Assert-FileContains -Path "docs/harness/issue-workflow.md" -Pattern $pattern -Message "docs/harness/issue-workflow.md missing required pattern: $pattern"
-}
-
-foreach ($pattern in @(
-    "Repo Issues",
-    "issue-provider=repo",
-    "issue_id",
-    "status",
-    "kind",
-    "goal",
-    "included",
-    "excluded",
-    "acceptance_matrix",
-    "stop_when",
-    "write_scope_limit",
-    "verification_commands",
-    "recovery_point",
-    "next_action",
-    "Orchestration",
-    "Current State",
-    "Thread Status Log",
-    "active_write_leases",
-    "post_integration_verify_summary",
-    "writeback_log"
-)) {
-    Assert-AnyFileContains -Paths @("docs/issues/README.md", "docs/issues/TEMPLATE.md") -Pattern $pattern -Message "docs/issues templates missing required pattern: $pattern"
-}
-
-foreach ($pattern in @(
-    "Project Mechanical Constraints",
-    "状态枚举",
-    "分类枚举",
-    "enforced",
-    "partial",
-    "documented",
-    "planned",
-    "not_applicable",
-    "architecture",
-    "contract",
-    "runtime",
-    "verification",
-    "docs",
-    "security",
-    "cross-repo",
-    "维护循环关联",
-    "maintenance_candidate",
-    "rule_promotion_candidate",
-    "human_decision_required",
-    "Maintenance Tag",
-    "Rule ID | Category | Rule | Source | Enforcement | Command | Status | Maintenance Tag | Notes",
-    "project-check",
-    "没有可执行命令或 gate 时，不得假装 `enforced`",
-    "repeated review finding"
-)) {
-    Assert-FileContains -Path "docs/harness/project-constraints.md" -Pattern $pattern -Message "docs/harness/project-constraints.md missing required pattern: $pattern"
-}
-
-foreach ($pattern in @(
-    "Test Runbook Template",
-    "当前验证结果",
-    "本次执行结果",
-    "执行副作用",
-    "前置条件",
-    "测试变量 / 初始化",
-    "主路径",
-    "清理结果",
-    "结果回写",
-    "runbook"
-)) {
-    Assert-FileContains -Path "docs/test/RUNBOOK_TEMPLATE.md" -Pattern $pattern -Message "docs/test/RUNBOOK_TEMPLATE.md missing required pattern: $pattern"
-}
-
-foreach ($pattern in @(
-    "Linear Profile",
-    "issue-workflow.md",
-    "Linear 字段映射",
-    "current_issue_state",
-    "Current State",
-    "Thread Status",
-    "write_lease",
-    "post-integration verify",
-    "【完成】",
-    "recovery_point",
-    "next_action",
-    "Issue Tracker 是主协作真相"
-)) {
-    Assert-FileContains -Path "docs/harness/linear.md" -Pattern $pattern -Message "docs/harness/linear.md missing required pattern: $pattern"
-}
-
-if ((Get-FileText -Path ".agents/PLANS.md").IndexOf("docs/harness/prompt-templates.md", [System.StringComparison]::Ordinal) -ge 0) {
-    Fail ".agents/PLANS.md should not reference docs/harness/prompt-templates.md anymore"
-}
-
-foreach ($pattern in @(
-    "文档定位",
-    "计划实例位置",
-    "何时必须写 plan",
-    "计划文件位置与命名",
-    "计划文档最小结构",
-    "技术实现型任务推荐写法",
-    "frontmatter 推荐但不强制",
-    "EXAMPLE-implementation.md",
-    "内容标准",
-    "禁止写法",
-    "真实入口与触发",
-    "输入装配与边界校验",
-    "组件职责与代码落点",
-    "关键执行时序",
-    "停止 / 错误 / 恢复",
-    "实现步骤",
-    "验证与收口步骤",
-    "入口代码位置",
-    "装配结果 / 核心对象",
-    "步骤化时序",
-    "关键分支 / 降级路径",
-    "Reference Snippets",
-    "File Map",
-    "伪代码 / 主循环",
-    "关键分支与实现策略",
-    "竞态 / 状态机分析",
-    "Mermaid 使用规则",
-    "代码示例使用规则",
-    "维护规则",
-    "Maintenance Loop 计划要求",
-    "rule-promotion",
-    "Maintenance Findings",
-    "Issue Tracker 默认约定"
-)) {
-    Assert-FileContains -Path ".agents/PLANS.md" -Pattern $pattern -Message ".agents/PLANS.md missing required section or keyword: $pattern"
-}
-
-foreach ($required in @("issue_provider", "issue_project", "current_issue_state", "recovery_point", "next_action", "state_ref", "latest_run_ref", "master_run_ref")) {
-    Assert-FileContains -Path ".agents/plans/TEMPLATE.md" -Pattern $required -Message ".agents/plans/TEMPLATE.md missing required field: $required"
-}
-
-foreach ($pattern in @(
-    "name: <任务名>",
-    "overview:",
-    "todos:",
-    "isProject: false",
-    "## Goal",
-    "## Scope Freeze",
-    "## Context and Orientation",
-    "## 0. 现有架构回顾与核心设计决策",
-    "### 真实入口与触发",
-    "入口代码位置",
-    "### 输入装配与边界校验",
-    "装配结果 / 核心对象",
-    "### 组件职责与代码落点",
-    "关键产物",
-    "### 关键执行时序",
-    "步骤化时序",
-    "### 停止 / 错误 / 恢复",
-    "关键分支 / 降级路径",
-    "## 1. <改动面> -- <本次变更>",
-    "## 数据流可视化",
-    "## 关键设计决策摘要",
-    "## 与现有代码的关系",
-    "## File Map（按需）",
-    "## 关键分支与实现策略（按需）",
-    "## 伪代码 / 主循环（按需）",
-    "## 竞态 / 状态机分析（按需）",
-    "## Reference Snippets",
-    "## Concrete Steps",
-    "### 实现步骤",
-    "### 验证与收口步骤",
-    "## Progress",
-    "## Decision Log",
-    "## Surprises & Discoveries",
-    "## Validation and Acceptance",
-    "## Idempotence and Recovery",
-    "## Outcomes & Retrospective"
-)) {
-    Assert-FileContains -Path ".agents/plans/TEMPLATE.md" -Pattern $pattern -Message ".agents/plans/TEMPLATE.md missing required pattern: $pattern"
-}
-
-foreach ($pattern in @(
-    "name:",
-    "overview:",
-    "todos:",
-    "isProject:",
-    "## Goal",
-    "## 0. 现有架构回顾与核心设计决策",
-    "## 1. HTTP 入口层 -- 收口请求与幂等键",
-    "## 数据流可视化",
-    "## 关键设计决策摘要",
-    "## 与现有代码的关系",
-    "## Reference Snippets",
-    "## Review Summary"
-)) {
-    Assert-FileContains -Path ".agents/plans/EXAMPLE-implementation.md" -Pattern $pattern -Message ".agents/plans/EXAMPLE-implementation.md missing required pattern: $pattern"
-}
-
-foreach ($pattern in @(
-    "State Snapshot Template",
-    "Run Summary Template",
-    "Issue Tracker",
-    "orchestration_mode",
-    "root_goal",
-    "goal_state",
-    "goal_unit_roster",
-    "active_write_leases",
-    "waiting_on",
-    "next_check",
-    "post_integration_verify",
-    "recovery_point"
-)) {
-    Assert-AnyFileContains -Paths @(".agents/state/TEMPLATE.md", ".agents/runs/TEMPLATE.md") -Pattern $pattern -Message "state/run templates missing required pattern: $pattern"
-}
-
-foreach ($pattern in @(
-    "Get-PlanImplementationSkeletonErrors",
-    "Resolve-PlanImplementationSection",
-    "Reference Snippets",
-    "组件职责与代码落点"
-)) {
-    Assert-FileContains -Path "scripts/harness/common.ps1" -Pattern $pattern -Message "scripts/harness/common.ps1 missing required pattern: $pattern"
-}
-
-foreach ($pattern in @(
-    "Get-PlanImplementationSkeletonErrors",
-    "blocking_findings",
-    "result=pass",
-    "result=fail"
-)) {
-    Assert-FileContains -Path "scripts/harness/review_gate.ps1" -Pattern $pattern -Message "scripts/harness/review_gate.ps1 missing required pattern: $pattern"
-}
-
-Assert-FileContains -Path "scripts/harness/check.ps1" -Pattern "harness check passed" -Message "scripts/harness/check.ps1 missing smoke completion marker"
 
 $optionalModeFiles = @(
     ".agents/prompts/orchestrator-thread.md",
@@ -563,552 +222,81 @@ $optionalModeFiles = @(
     ".agents/guides/code-review.md",
     ".agents/guides/linter.md"
 )
-
-$optionalBundleFiles = @(
-    ".agents/prompts/README.md",
-    ".agents/prompts/orchestrator-thread.md",
-    ".agents/prompts/issue-standard-workflow.md",
-    ".agents/prompts/loop-codex.md",
-    ".agents/prompts/loop-automation.md",
-    ".agents/prompts/maintenance-loop.md",
-    ".agents/guides/code-review.md",
-    ".agents/guides/linter.md"
-)
-
+$optionalBundleFiles = @(".agents/prompts/README.md") + $optionalModeFiles
 $hasOptionalBundle = $false
 foreach ($path in $optionalBundleFiles) {
-    if (Test-Path -LiteralPath $path -PathType Leaf) {
-        $hasOptionalBundle = $true
-        break
-    }
+    if (Test-Path -LiteralPath $path -PathType Leaf) { $hasOptionalBundle = $true; break }
 }
 
 if ($hasOptionalBundle) {
     foreach ($path in $optionalBundleFiles) {
         if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
-            Fail "Optional agent extension bundle is incomplete: missing $path"
+            Fail -Message "Optional agent extension bundle is incomplete: missing $path"
         }
     }
 
     $detectedMode = ""
     foreach ($path in $optionalModeFiles) {
-        $firstLine = (Get-Content -LiteralPath $path -TotalCount 1 -Encoding UTF8)
-        if ($firstLine -notmatch '^Mode: (placeholder|full)$') {
-            Fail "Optional harness file missing valid mode marker: $path"
+        $firstLine = Get-Content -LiteralPath $path -TotalCount 1
+        if ($firstLine -notin @("Mode: placeholder", "Mode: full")) {
+            Fail -Message "Optional harness file missing valid mode marker: $path"
         }
-        $currentMode = $Matches[1]
+        $currentMode = $firstLine.Substring("Mode: ".Length)
         if ([string]::IsNullOrEmpty($detectedMode)) {
             $detectedMode = $currentMode
         } elseif ($detectedMode -ne $currentMode) {
-            Fail "Optional agent extension bundle has mixed modes: expected $detectedMode, got $currentMode in $path"
-        }
-    }
-
-    foreach ($pattern in @("orchestrator-thread.md", "issue-standard-workflow.md", "loop-codex.md", "loop-automation.md", "maintenance-loop.md")) {
-        Assert-FileContains -Path ".agents/prompts/README.md" -Pattern $pattern -Message ".agents/prompts/README.md missing prompt reference: $pattern"
-    }
-
-    Assert-FileContains -Path ".agents/guides/linter.md" -Pattern "docs/harness/project-constraints.md" -Message ".agents/guides/linter.md should point project-level mechanical constraints back to docs/harness/project-constraints.md"
-
-    if ($detectedMode -eq "full") {
-        foreach ($pattern in @(
-            "goal-orchestration",
-            "write_lease",
-            "Current State",
-            "Thread Status",
-            "post-integration verify",
-            "waiting_on_child",
-            "【完成】",
-            "set_thread_title"
-        )) {
-            Assert-FileContains -Path ".agents/prompts/orchestrator-thread.md" -Pattern $pattern -Message ".agents/prompts/orchestrator-thread.md missing required pattern: $pattern"
-        }
-
-        foreach ($pattern in @(
-            "真实入口与触发",
-            "输入装配与边界校验",
-            "组件职责与代码落点",
-            "关键执行时序",
-            "停止 / 错误 / 恢复",
-            "入口代码位置",
-            "装配结果 / 核心对象",
-            "步骤化时序",
-            "关键分支 / 降级路径",
-            "File Map",
-            "伪代码 / 主循环",
-            "关键分支与实现策略",
-            "竞态 / 状态机分析",
-            "不要用 harness 控制流替代业务实现图",
-            "不要只画图，不写步骤化时序",
-            "不要只写职责，不写代码落点",
-            "不要只写 happy path，不写关键分支 / 降级路径",
-            "不要把 Concrete Steps 写成纯控制面收口步骤",
-            "orchestrator-thread.md",
-            "write_lease",
-            "post-integration verify",
-            "【完成】"
-        )) {
-            Assert-FileContains -Path ".agents/prompts/issue-standard-workflow.md" -Pattern $pattern -Message ".agents/prompts/issue-standard-workflow.md missing required pattern: $pattern"
-        }
-
-        foreach ($pattern in @(
-            "report-only",
-            "issue-create",
-            "safe-fix",
-            "rule-promotion",
-            "Maintenance Findings",
-            "Classification",
-            "Verification Plan",
-            "Writeback Plan",
-            "Residual Risks",
-            "Next Action",
-            "rule_promotion_candidate",
-            "human_decision_required"
-        )) {
-            Assert-FileContains -Path ".agents/prompts/maintenance-loop.md" -Pattern $pattern -Message ".agents/prompts/maintenance-loop.md missing required pattern: $pattern"
+            Fail -Message "Optional agent extension bundle has mixed modes: expected $detectedMode, got $currentMode in $path"
         }
     }
 }
 
-$tempPlans = New-Object System.Collections.Generic.List[string]
+$tmpPlan = [System.IO.Path]::GetTempFileName()
+$tmpBlockingPlan = [System.IO.Path]::GetTempFileName()
+$tmpEvidenceRepo = Join-Path ([System.IO.Path]::GetTempPath()) ("harness-evidence-smoke-" + [guid]::NewGuid().ToString("N"))
 
 try {
-    function New-PlanFixture {
-        param([Parameter(Mandatory=$true)][string]$Content)
-
-        $path = [System.IO.Path]::GetTempFileName()
-        Set-Content -LiteralPath $path -Value $Content -Encoding UTF8
-        [void]$tempPlans.Add($path)
-        return $path
-    }
-
-    $tmpPlanNew = New-PlanFixture @'
----
-name: harness smoke new
-overview: verify implementation-first plan shape
-todos:
-  - id: smoke
-    content: validate new review gate path
-    status: pending
-isProject: false
----
-
-# ExecPlan: harness smoke new
-
-## Goal
-- 目标：验证新模板风格的 plan 可以通过 review gate。
-- 成功标准：review gate 返回 pass。
-
-## Scope Freeze
-
-| 类别 | 本次纳入 |
-| --- | --- |
-| gate smoke | `review_gate` 正反例 |
-
-## Context and Orientation
-
-- 当前仓库现状：只需要验证新模板 contract。
-- 关键入口文件 / 文档：`scripts/harness/review_gate.ps1`
-- 可复用组件 / 已有能力：`common.ps1`
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`powershell -File scripts/harness/review_gate.ps1`
-- `入口代码位置`：`scripts/harness/review_gate.ps1`
-- `触发条件 / 上游依赖`：传入合法 plan 路径即可
-
-### 输入装配与边界校验
-- `输入来源`：CLI 参数 `-Plan`
-- `装配位置`：`review_gate.ps1`
-- `装配结果 / 核心对象`：待校验的 plan 文件路径
-- `边界校验`：plan 文件不存在时直接失败
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `scripts/harness/review_gate.ps1` | 复用 | `review gate` | 读取 plan 并输出 pass / fail | 不负责实现业务逻辑 |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["PowerShell gate"] --> Gate["review_gate.ps1"]
-    Gate --> Result["pass/fail"]
-```
-- `图示说明`：PowerShell 入口读取 plan 后给出结论。
-- `步骤化时序`：
-  1. check script 传入 `-Plan` 参数。
-  2. review gate 读取 plan 并检查实现骨架。
-  3. blocking findings 为 none 时输出 pass。
-- `关键状态推进 / 数据流`：输入路径被解析为一个待校验 plan，最后输出 gate 结果。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：plan 通过校验并输出 pass。
-- `主要错误出口`：plan 缺字段或缺结构时输出 fail。
-- `关键分支 / 降级路径`：缺少实现骨架时立即失败，不继续读取 review 结果。
-- `恢复 / 重试 / 回滚`：补全 plan 后可安全重跑。
-
-## Reference Snippets
-
-```text
-result=pass
-blocking_findings=none
-```
-
-- `片段说明`：锁定 gate 成功时的最小输出形状。
-
-## Concrete Steps
-
-### 实现步骤
-1. 读取 plan。
-2. 校验实现骨架。
-
-## Review Summary
-- `blocking_findings`: none
-'@
-
-    $tmpPlanLegacy = New-PlanFixture @'
-# ExecPlan: harness smoke legacy
-
-## Architecture / Data Flow
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：`SmokeRunnerConfig`
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `internal/demo/runner.go` | 新增 | `SmokeRunner` | 串接 smoke runner 并返回结果 | 不负责网络重试 |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["CLI"] --> Runner["SmokeRunner"]
-```
-- `图示说明`：CLI 触发 smoke runner。
-- `步骤化时序`：
-  1. root command 解析参数并构造 config。
-  2. runner 消费 config 并返回结果摘要。
-- `关键状态推进 / 数据流`：输入参数归一化后进入 runner。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：无 pipeline 时降级为失败返回，不启动 runner。
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-```text
-SmokeRunnerConfig{Pipeline: "smoke"}
-```
-
-- `片段说明`：锁定 smoke runner 的最小输入对象。
-
-## Concrete Steps
-
-### 实现步骤
-1. 编写 smoke runner。
-
-## Review Summary
-- `blocking_findings`: none
-'@
-
-    $tmpBadPlanNoSteps = New-PlanFixture @'
-# ExecPlan: harness smoke bad no steps
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：`SmokeRunnerConfig`
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `internal/demo/runner.go` | 新增 | `SmokeRunner` | 串接 smoke runner 并返回结果 | 不负责网络重试 |
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：无 pipeline 时降级为失败返回，不启动 runner。
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-```text
-SmokeRunnerConfig{Pipeline: "smoke"}
-```
-
-## Concrete Steps
-
-### 实现步骤
-1. verify
-
-## Review Summary
-- `blocking_findings`: none
-'@
-
-    $tmpBadPlanNoCore = New-PlanFixture @'
-# ExecPlan: harness smoke bad no core object
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `internal/demo/runner.go` | 新增 | `SmokeRunner` | 串接 smoke runner 并返回结果 | 不负责网络重试 |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["CLI"] --> Runner["SmokeRunner"]
-```
-- `图示说明`：CLI 触发 smoke runner。
-- `步骤化时序`：
-  1. root command 解析参数并构造 config。
-- `关键状态推进 / 数据流`：输入参数归一化后进入 runner。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：无 pipeline 时降级为失败返回，不启动 runner。
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-```text
-SmokeRunnerConfig{Pipeline: "smoke"}
-```
-
-## Concrete Steps
-
-### 实现步骤
-1. 编写 smoke runner。
-
-## Review Summary
-- `blocking_findings`: none
-'@
-
-    $tmpBadPlanNoBranch = New-PlanFixture @'
-# ExecPlan: harness smoke bad no branch
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：`SmokeRunnerConfig`
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `internal/demo/runner.go` | 新增 | `SmokeRunner` | 串接 smoke runner 并返回结果 | 不负责网络重试 |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["CLI"] --> Runner["SmokeRunner"]
-```
-- `图示说明`：CLI 触发 smoke runner。
-- `步骤化时序`：
-  1. root command 解析参数并构造 config。
-- `关键状态推进 / 数据流`：输入参数归一化后进入 runner。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-```text
-SmokeRunnerConfig{Pipeline: "smoke"}
-```
-
-## Concrete Steps
-
-### 实现步骤
-1. 编写 smoke runner。
-
-## Review Summary
-- `blocking_findings`: none
-'@
-
-    $tmpBadPlanNoSnippets = New-PlanFixture @'
-# ExecPlan: harness smoke bad no snippets
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：`SmokeRunnerConfig`
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `internal/demo/runner.go` | 新增 | `SmokeRunner` | 串接 smoke runner 并返回结果 | 不负责网络重试 |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["CLI"] --> Runner["SmokeRunner"]
-```
-- `图示说明`：CLI 触发 smoke runner。
-- `步骤化时序`：
-  1. root command 解析参数并构造 config。
-- `关键状态推进 / 数据流`：输入参数归一化后进入 runner。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：无 pipeline 时降级为失败返回，不启动 runner。
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-## Concrete Steps
-
-### 实现步骤
-1. 编写 smoke runner。
-
-## Review Summary
-- `blocking_findings`: none
-'@
-
-    $tmpBadPlanNoComponentRow = New-PlanFixture @'
-# ExecPlan: harness smoke bad no component row
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：`SmokeRunnerConfig`
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["CLI"] --> Runner["SmokeRunner"]
-```
-- `图示说明`：CLI 触发 smoke runner。
-- `步骤化时序`：
-  1. root command 解析参数并构造 config。
-- `关键状态推进 / 数据流`：输入参数归一化后进入 runner。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：无 pipeline 时降级为失败返回，不启动 runner。
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-```text
-SmokeRunnerConfig{Pipeline: "smoke"}
-```
-
-## Concrete Steps
-
-### 实现步骤
-1. 编写 smoke runner。
-
-## Review Summary
-- `blocking_findings`: none
-'@
-
-    $tmpBadPlanHarnessFlow = New-PlanFixture @'
-# ExecPlan: harness smoke bad harness flow
-
-## Architecture / Data Flow
-
-```mermaid
-flowchart TD
-    Collect["collect"] --> Verify["verify"]
-    Verify --> Review["review"]
-    Review --> Notify["notify"]
-```
-
-## Reference Snippets
-
-```text
-result=pass
-```
-
-## Concrete Steps
-
-### 实现步骤
-1. 运行控制面。
-
-## Review Summary
-- `blocking_findings`: none
-'@
-
-    Test-ReviewGate -Plan $tmpPlanNew -ShouldPass $true -FailureMessage "review_gate.ps1 should pass for a new implementation-first plan"
-    Test-ReviewGate -Plan $tmpPlanLegacy -ShouldPass $true -FailureMessage "review_gate.ps1 should still pass for a legacy plan without frontmatter"
-    Test-ReviewGate -Plan $tmpBadPlanNoSteps -ShouldPass $false -FailureMessage "review_gate.ps1 should fail for a plan without step-by-step flow"
-    Test-ReviewGate -Plan $tmpBadPlanNoCore -ShouldPass $false -FailureMessage "review_gate.ps1 should fail for a plan without core object/result"
-    Test-ReviewGate -Plan $tmpBadPlanNoBranch -ShouldPass $false -FailureMessage "review_gate.ps1 should fail for a plan without key branch/degrade path"
-    Test-ReviewGate -Plan $tmpBadPlanNoSnippets -ShouldPass $false -FailureMessage "review_gate.ps1 should fail for a plan without reference snippets"
-    Test-ReviewGate -Plan $tmpBadPlanNoComponentRow -ShouldPass $false -FailureMessage "review_gate.ps1 should fail for a plan without a real component responsibility entry"
-    Test-ReviewGate -Plan $tmpBadPlanHarnessFlow -ShouldPass $false -FailureMessage "review_gate.ps1 should fail for a plan that only contains harness flow"
-}
-finally {
-    foreach ($path in $tempPlans) {
-        if (Test-Path -LiteralPath $path) {
-            Remove-Item -LiteralPath $path -Force
+    Copy-Item -LiteralPath ".agents/plans/EXAMPLE-implementation.md" -Destination $tmpPlan -Force
+    $blockingText = [System.IO.File]::ReadAllText($tmpPlan).Replace(
+        '`blocking_findings`: none',
+        '`blocking_findings`: correctness regression'
+    )
+    [System.IO.File]::WriteAllText($tmpBlockingPlan, $blockingText)
+    Invoke-ReviewGateProcess -Plan $tmpPlan -ShouldPass $true `
+        -Message "review gate should pass for the implementation example"
+    Invoke-ReviewGateProcess -Plan $tmpBlockingPlan -ShouldPass $false `
+        -Message "review gate should fail when blocking findings are present"
+
+    New-Item -ItemType Directory -Path $tmpEvidenceRepo -Force | Out-Null
+    & git init -q $tmpEvidenceRepo
+    & git -C $tmpEvidenceRepo config user.name "Harness Check"
+    & git -C $tmpEvidenceRepo config user.email "harness-check@example.invalid"
+    [System.IO.File]::WriteAllText((Join-Path $tmpEvidenceRepo "value.txt"), "base`n")
+    & git -C $tmpEvidenceRepo add value.txt
+    & git -C $tmpEvidenceRepo commit -qm "test: evidence base"
+
+    Push-Location $tmpEvidenceRepo
+    try {
+        $evidenceScript = Join-Path $repoRoot "scripts\harness\evidence.ps1"
+        $first = @(& $evidenceScript -Action Snapshot)
+        $second = @(& $evidenceScript -Action Snapshot)
+        $firstId = Get-OutputField -Lines $first -Name "evidence_id"
+        $secondId = Get-OutputField -Lines $second -Name "evidence_id"
+        if ([string]::IsNullOrWhiteSpace($firstId) -or $firstId -ne $secondId) {
+            Fail -Message "evidence helper should be stable for an unchanged repository"
         }
+
+        [System.IO.File]::AppendAllText((Join-Path $tmpEvidenceRepo "value.txt"), "changed`n")
+        $changed = @(& $evidenceScript -Action Snapshot)
+        $changedId = Get-OutputField -Lines $changed -Name "evidence_id"
+        if ([string]::IsNullOrWhiteSpace($changedId) -or $changedId -eq $firstId) {
+            Fail -Message "evidence helper should change after repository content changes"
+        }
+    } finally {
+        Pop-Location
     }
+} finally {
+    Remove-Item -LiteralPath $tmpPlan, $tmpBlockingPlan -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $tmpEvidenceRepo -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 Write-Output "harness check passed"

--- a/template/scripts/harness/check.sh
+++ b/template/scripts/harness/check.sh
@@ -2,8 +2,13 @@
 
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 cd "$repo_root"
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
 
 required_files=(
   ".gitignore"
@@ -37,17 +42,20 @@ required_files=(
   "scripts/harness/check.sh"
   "scripts/harness/common.sh"
   "scripts/harness/review_gate.sh"
+  "scripts/harness/evidence.sh"
   "scripts/harness/check.ps1"
   "scripts/harness/common.ps1"
   "scripts/harness/review_gate.ps1"
+  "scripts/harness/evidence.ps1"
 )
 
 for path in "${required_files[@]}"; do
-  if [[ ! -f "$path" ]]; then
-    echo "Missing required harness file: $path" >&2
-    exit 1
-  fi
+  [[ -f "$path" ]] || fail "Missing required harness file: $path"
 done
+
+if [[ -f "docs/harness/prompt-templates.md" ]]; then
+  fail "Obsolete harness file should not exist anymore: docs/harness/prompt-templates.md"
+fi
 
 required_skill_frontmatter=(
   ".agents/skills/issue-goal-prompt/SKILL.md|name: issue-goal-prompt"
@@ -59,48 +67,13 @@ required_skill_frontmatter=(
 for item in "${required_skill_frontmatter[@]}"; do
   path="${item%%|*}"
   pattern="${item#*|}"
-  if ! rg -Fq -- "---" "$path" || ! rg -Fq "$pattern" "$path" || ! rg -Fq "description:" "$path"; then
-    echo "Skill frontmatter is incomplete: $path" >&2
-    exit 1
-  fi
-done
-
-required_skill_patterns=(
-  ".agents/skills/issue-goal-prompt/SKILL.md|任务系统"
-  ".agents/skills/issue-goal-prompt/SKILL.md|状态文件规则"
-  ".agents/skills/issue-goal-prompt/SKILL.md|pre-commit ready"
-  ".agents/skills/issue-goal-prompt/SKILL.md|subagent_review_unavailable"
-  ".agents/skills/issue-goal-prompt/SKILL.md|manual_gate_live_e2e"
-  ".agents/skills/issue-goal-prompt/references/goal-prompt-template.md|完整目标提示词"
-  ".agents/skills/issue-goal-prompt/references/goal-prompt-template.md|状态文件模板"
-  ".agents/skills/issue-goal-prompt/references/goal-prompt-template.md|短启动提示词"
-  ".agents/skills/project-plan-archive/SKILL.md|先查 Issue Tracker，再归档"
-  ".agents/skills/project-plan-archive/SKILL.md|--done-issue"
-  ".agents/skills/project-plan-archive/SKILL.md|no_issue_default_archive"
-  ".agents/skills/project-plan-archive/scripts/project_plan_archive.py|Project plan archive helper"
-  ".agents/skills/project-plan-archive/scripts/project_plan_archive.py|--write"
-  ".agents/skills/project-version-release/SKILL.md|issue 是执行粒度，release 是发布粒度"
-  ".agents/skills/project-version-release/SKILL.md|CHANGELOG.md -> Unreleased"
-  ".agents/skills/project-version-release/scripts/project_version_release.py|Project version/release helper"
-  ".agents/skills/project-version-release/references/project-version-policy.md|Project Version Policy"
-  ".agents/skills/test-runbook/SKILL.md|执行副作用"
-  ".agents/skills/test-runbook/SKILL.md|Request / Response 回写规则"
-  ".agents/skills/test-runbook/SKILL.md|提交版证据边界"
-  ".agents/skills/test-runbook/SKILL.md|结果回写规则"
-)
-
-for item in "${required_skill_patterns[@]}"; do
-  path="${item%%|*}"
-  pattern="${item#*|}"
-  if ! rg -Fq -- "$pattern" "$path"; then
-    echo "$path missing required skill pattern: $pattern" >&2
-    exit 1
-  fi
+  rg -Fq -- "---" "$path" || fail "Skill frontmatter is incomplete: $path"
+  rg -Fq "$pattern" "$path" || fail "Skill frontmatter is incomplete: $path"
+  rg -Fq "description:" "$path" || fail "Skill frontmatter is incomplete: $path"
 done
 
 if rg -n "DBBridge|db_bridge_test|/Users/suqing|TEA-" .agents/skills >/dev/null; then
-  echo "Default harness skills must not contain DBBridge-specific constants" >&2
-  exit 1
+  fail "Default harness skills must not contain project-specific constants"
 fi
 
 if command -v python3 >/dev/null 2>&1; then
@@ -108,22 +81,8 @@ if command -v python3 >/dev/null 2>&1; then
   python3 .agents/skills/project-version-release/scripts/project_version_release.py --help >/dev/null
 fi
 
-if [[ -f "docs/harness/prompt-templates.md" ]]; then
-  echo "Obsolete harness file should not exist anymore: docs/harness/prompt-templates.md" >&2
-  exit 1
-fi
-
-required_make_targets=(
-  "harness-check"
-  "harness-verify"
-  "harness-review-gate"
-)
-
-for target in "${required_make_targets[@]}"; do
-  if ! rg -q "^${target}:" Makefile; then
-    echo "Makefile missing target: $target" >&2
-    exit 1
-  fi
+for target in "harness-check" "harness-verify" "harness-review-gate"; do
+  rg -q "^${target}:" Makefile || fail "Makefile missing target: $target"
 done
 
 required_gitignore_patterns=(
@@ -144,387 +103,61 @@ required_gitignore_patterns=(
 )
 
 for pattern in "${required_gitignore_patterns[@]}"; do
-  if ! rg -Fq "$pattern" .gitignore; then
-    echo ".gitignore missing required pattern: $pattern" >&2
-    exit 1
-  fi
+  rg -Fq -- "$pattern" .gitignore || fail ".gitignore missing required pattern: $pattern"
 done
 
-if ! rg -Fq "EXAMPLE-implementation.md" README.md AGENTS.md; then
-  echo "Base harness output should point readers to EXAMPLE-implementation.md" >&2
-  exit 1
+project_placeholder='__PROJECT''_NAME__'
+provider_placeholder='__PROVIDER''__'
+issue_provider_placeholder='__ISSUE''_PROVIDER__'
+issue_prefix_placeholder='__ISSUE''_PREFIX__'
+placeholder_regex="${project_placeholder}|${provider_placeholder}|${issue_provider_placeholder}|${issue_prefix_placeholder}"
+
+template_source=0
+source_harness_root="$(cd "$repo_root/.." && pwd -P)"
+canonical_source_template=""
+if [[ -d "$source_harness_root/template" ]]; then
+  canonical_source_template="$(cd "$source_harness_root/template" && pwd -P)"
+fi
+if rg -Fq "# $project_placeholder" README.md \
+  && rg -Fq "$provider_placeholder" docs/harness/control-plane.md \
+  && rg -Fq "$issue_provider_placeholder" docs/harness/control-plane.md \
+  && [[ -f "$source_harness_root/scripts/verify_harness_source.sh" ]] \
+  && [[ -f "$source_harness_root/scripts/verify_harness_source.ps1" ]] \
+  && [[ -d "$source_harness_root/sources/agent_extensions" ]] \
+  && [[ -n "$canonical_source_template" ]] \
+  && [[ "$repo_root" == "$canonical_source_template" ]]; then
+  template_source=1
 fi
 
-if rg -n "^docs/test" .gitignore >/dev/null; then
-  echo ".gitignore should not ignore docs/test runbook documents" >&2
-  exit 1
+if [[ "$template_source" -eq 0 ]]; then
+  if rg -n --hidden -g '!scripts/harness/check.sh' \
+    "$placeholder_regex" \
+    AGENTS.md README.md docs .agents Makefile >/dev/null; then
+    fail "Unresolved harness initializer placeholder detected"
+  fi
+
+  merge_provider="$(awk '
+    /当前 merge provider：/ { found=1; next }
+    found && /^- `/ { value=$0; sub(/^- `/, "", value); sub(/`.*$/, "", value); print value; exit }
+  ' docs/harness/control-plane.md)"
+  issue_provider="$(awk '
+    /当前 issue provider：/ { found=1; next }
+    found && /^- `/ { value=$0; sub(/^- `/, "", value); sub(/`.*$/, "", value); print value; exit }
+  ' docs/harness/control-plane.md)"
+
+  [[ "$merge_provider" =~ ^(neutral|github|gitlab)$ ]] \
+    || fail "Invalid merge provider: ${merge_provider:-missing}"
+  [[ "$issue_provider" =~ ^(linear|github|gitlab|repo|other)$ ]] \
+    || fail "Invalid issue provider: ${issue_provider:-missing}"
+
 fi
 
 if [[ -f ".cursor/rules/harness.mdc" ]]; then
-  required_cursor_rule_patterns=(
-    "description: 始终使用本仓库的 harness 控制面、计划模板、测试 runbook 和验证 gate"
-    "alwaysApply: true"
-    "AGENTS.md"
-    '目录级 `AGENTS.md`'
-    "docs/harness/control-plane.md"
-    "docs/harness/issue-workflow.md"
-    "docs/harness/linear.md"
-    "docs/harness/project-constraints.md"
-    "docs/issues/README.md"
-    ".agents/PLANS.md"
-    ".agents/plans/TEMPLATE.md"
-    ".agents/plans/EXAMPLE-implementation.md"
-    "docs/test/RUNBOOK_TEMPLATE.md"
-    "make harness-verify"
-    "check.ps1"
-  )
-
-  for pattern in "${required_cursor_rule_patterns[@]}"; do
-    if ! rg -Fq "$pattern" ".cursor/rules/harness.mdc"; then
-      echo ".cursor/rules/harness.mdc missing required pattern: $pattern" >&2
-      exit 1
-    fi
-  done
+  rg -Fq "alwaysApply: true" .cursor/rules/harness.mdc \
+    || fail ".cursor/rules/harness.mdc missing alwaysApply: true"
+  rg -Fq "make harness-verify" .cursor/rules/harness.mdc \
+    || fail ".cursor/rules/harness.mdc missing harness verification entry"
 fi
-
-required_control_plane_patterns=(
-  "collect -> gate -> freeze -> slice -> dispatch -> implement -> verify -> review -> integrate -> verify -> writeback -> pr_prep -> merge -> notify"
-  "Issue Tracker 是主协作真相"
-  "repo 是主执行真相"
-  "goal-orchestration"
-  "write_lease"
-  "Current State"
-  "Thread Status"
-  "post-integration verify"
-  "waiting_on_child"
-  "【完成】"
-  "Issue Store Profiles"
-  "docs/issues/"
-  "provider 仓"
-  "consumer 仓"
-  "project-constraints.md"
-  "项目级机械约束"
-  "Maintenance Loop"
-  "report-only"
-  "rule-promotion"
-  "目录级 AGENTS"
-  ".agents/skills"
-  "运行反馈默认写回 Issue Tracker"
-  "结果回写默认写回 Issue Tracker"
-  "review_gate"
-  "check.ps1"
-  "merge"
-  "escalation"
-  ".agents/PLANS.md"
-  ".agents/plans/TEMPLATE.md"
-)
-
-for pattern in "${required_control_plane_patterns[@]}"; do
-  if ! rg -Fq "$pattern" docs/harness/control-plane.md; then
-    echo "docs/harness/control-plane.md missing required pattern: $pattern" >&2
-    exit 1
-  fi
-done
-
-required_issue_workflow_patterns=(
-  "Issue Workflow"
-  "Issue Tracker 是主协作真相"
-  "Issue Store Profiles"
-  "Orchestration Contract"
-  "Current State Comment Contract"
-  "Thread Status Comment Contract"
-  "Write Lease Contract"
-  "Post-Integration Verify Contract"
-  "goal-orchestration"
-  "write_lease"
-  "【完成】"
-  "Requirement Clarification"
-  "Master Issue"
-  "Execution Issue"
-  "Codex Handoff"
-  "运行反馈 Comment Contract"
-  "结果回写 Contract"
-  "recovery_point"
-  "next_action"
-  "current_issue_state"
-  "Master 是否可置 Done"
-)
-
-for pattern in "${required_issue_workflow_patterns[@]}"; do
-  if ! rg -Fq "$pattern" docs/harness/issue-workflow.md; then
-    echo "docs/harness/issue-workflow.md missing required pattern: $pattern" >&2
-    exit 1
-  fi
-done
-
-required_repo_issue_patterns=(
-  "Repo Issues"
-  "issue-provider=repo"
-  "issue_id"
-  "status"
-  "kind"
-  "goal"
-  "included"
-  "excluded"
-  "acceptance_matrix"
-  "stop_when"
-  "write_scope_limit"
-  "verification_commands"
-  "recovery_point"
-  "next_action"
-  "Orchestration"
-  "Current State"
-  "Thread Status Log"
-  "active_write_leases"
-  "post_integration_verify_summary"
-  "writeback_log"
-)
-
-for pattern in "${required_repo_issue_patterns[@]}"; do
-  if ! rg -Fq "$pattern" docs/issues/README.md docs/issues/TEMPLATE.md; then
-    echo "docs/issues templates missing required pattern: $pattern" >&2
-    exit 1
-  fi
-done
-
-required_project_constraints_patterns=(
-  "Project Mechanical Constraints"
-  "状态枚举"
-  "分类枚举"
-  "enforced"
-  "partial"
-  "documented"
-  "planned"
-  "not_applicable"
-  "architecture"
-  "contract"
-  "runtime"
-  "verification"
-  "docs"
-  "security"
-  "cross-repo"
-  "维护循环关联"
-  "maintenance_candidate"
-  "rule_promotion_candidate"
-  "human_decision_required"
-  "Maintenance Tag"
-  "Rule ID | Category | Rule | Source | Enforcement | Command | Status | Maintenance Tag | Notes"
-  "project-check"
-  '没有可执行命令或 gate 时，不得假装 `enforced`'
-  "repeated review finding"
-)
-
-for pattern in "${required_project_constraints_patterns[@]}"; do
-  if ! rg -Fq "$pattern" docs/harness/project-constraints.md; then
-    echo "docs/harness/project-constraints.md missing required pattern: $pattern" >&2
-    exit 1
-  fi
-done
-
-required_test_runbook_patterns=(
-  "Test Runbook Template"
-  "当前验证结果"
-  "本次执行结果"
-  "执行副作用"
-  "前置条件"
-  "测试变量 / 初始化"
-  "主路径"
-  "清理结果"
-  "结果回写"
-  "runbook"
-)
-
-for pattern in "${required_test_runbook_patterns[@]}"; do
-  if ! rg -Fq "$pattern" docs/test/RUNBOOK_TEMPLATE.md; then
-    echo "docs/test/RUNBOOK_TEMPLATE.md missing required pattern: $pattern" >&2
-    exit 1
-  fi
-done
-
-required_linear_profile_patterns=(
-  "Linear Profile"
-  "issue-workflow.md"
-  "Linear 字段映射"
-  "current_issue_state"
-  "Current State"
-  "Thread Status"
-  "write_lease"
-  "post-integration verify"
-  "【完成】"
-  "recovery_point"
-  "next_action"
-  "Issue Tracker 是主协作真相"
-)
-
-for pattern in "${required_linear_profile_patterns[@]}"; do
-  if ! rg -Fq "$pattern" docs/harness/linear.md; then
-    echo "docs/harness/linear.md missing required pattern: $pattern" >&2
-    exit 1
-  fi
-done
-
-if rg -Fq "docs/harness/prompt-templates.md" .agents/PLANS.md; then
-  echo ".agents/PLANS.md should not reference docs/harness/prompt-templates.md anymore" >&2
-  exit 1
-fi
-
-required_plans_patterns=(
-  "文档定位"
-  "计划实例位置"
-  "何时必须写 plan"
-  "计划文件位置与命名"
-  "计划文档最小结构"
-  "技术实现型任务推荐写法"
-  "frontmatter 推荐但不强制"
-  "EXAMPLE-implementation.md"
-  "内容标准"
-  "禁止写法"
-  "真实入口与触发"
-  "输入装配与边界校验"
-  "组件职责与代码落点"
-  "关键执行时序"
-  "停止 / 错误 / 恢复"
-  "实现步骤"
-  "验证与收口步骤"
-  "入口代码位置"
-  "装配结果 / 核心对象"
-  "步骤化时序"
-  "关键分支 / 降级路径"
-  "Reference Snippets"
-  "File Map"
-  "伪代码 / 主循环"
-  "关键分支与实现策略"
-  "竞态 / 状态机分析"
-  "Mermaid 使用规则"
-  "代码示例使用规则"
-  "维护规则"
-  "Maintenance Loop 计划要求"
-  "rule-promotion"
-  "Maintenance Findings"
-  "Issue Tracker 默认约定"
-)
-
-for pattern in "${required_plans_patterns[@]}"; do
-  if ! rg -Fq "$pattern" .agents/PLANS.md; then
-    echo ".agents/PLANS.md missing required section or keyword: $pattern" >&2
-    exit 1
-  fi
-done
-
-for required in "issue_provider" "issue_project" "current_issue_state" "recovery_point" "next_action" "state_ref" "latest_run_ref" "master_run_ref"; do
-  if ! rg -Fq "$required" .agents/plans/TEMPLATE.md; then
-    echo ".agents/plans/TEMPLATE.md missing required field: $required" >&2
-    exit 1
-  fi
-done
-
-required_plan_template_patterns=(
-  "name: <任务名>"
-  "overview:"
-  "todos:"
-  "isProject: false"
-  "## Goal"
-  "## Scope Freeze"
-  "## Context and Orientation"
-  "## 0. 现有架构回顾与核心设计决策"
-  "### 真实入口与触发"
-  "入口代码位置"
-  "### 输入装配与边界校验"
-  "装配结果 / 核心对象"
-  "### 组件职责与代码落点"
-  "关键产物"
-  "### 关键执行时序"
-  "步骤化时序"
-  "### 停止 / 错误 / 恢复"
-  "关键分支 / 降级路径"
-  "## 1. <改动面> -- <本次变更>"
-  "## 数据流可视化"
-  "## 关键设计决策摘要"
-  "## 与现有代码的关系"
-  "## File Map（按需）"
-  "## 关键分支与实现策略（按需）"
-  "## 伪代码 / 主循环（按需）"
-  "## 竞态 / 状态机分析（按需）"
-  "## Reference Snippets"
-  "## Concrete Steps"
-  "### 实现步骤"
-  "### 验证与收口步骤"
-  "## Progress"
-  "## Decision Log"
-  "## Surprises & Discoveries"
-  "## Validation and Acceptance"
-  "## Idempotence and Recovery"
-  "## Outcomes & Retrospective"
-)
-
-for pattern in "${required_plan_template_patterns[@]}"; do
-  if ! rg -Fq "$pattern" .agents/plans/TEMPLATE.md; then
-    echo ".agents/plans/TEMPLATE.md missing required pattern: $pattern" >&2
-    exit 1
-  fi
-done
-
-required_example_patterns=(
-  "name:"
-  "overview:"
-  "todos:"
-  "isProject:"
-  "## Goal"
-  "## 0. 现有架构回顾与核心设计决策"
-  "## 1. HTTP 入口层 -- 收口请求与幂等键"
-  "## 数据流可视化"
-  "## 关键设计决策摘要"
-  "## 与现有代码的关系"
-  "## Reference Snippets"
-  "## Review Summary"
-)
-
-for pattern in "${required_example_patterns[@]}"; do
-  if ! rg -Fq "$pattern" .agents/plans/EXAMPLE-implementation.md; then
-    echo ".agents/plans/EXAMPLE-implementation.md missing required pattern: $pattern" >&2
-    exit 1
-  fi
-done
-
-required_state_run_patterns=(
-  "State Snapshot Template"
-  "Run Summary Template"
-  "Issue Tracker"
-  "orchestration_mode"
-  "root_goal"
-  "goal_state"
-  "goal_unit_roster"
-  "active_write_leases"
-  "waiting_on"
-  "next_check"
-  "post_integration_verify"
-  "recovery_point"
-)
-
-for pattern in "${required_state_run_patterns[@]}"; do
-  if ! rg -Fq "$pattern" .agents/state/TEMPLATE.md .agents/runs/TEMPLATE.md; then
-    echo "state/run templates missing required pattern: $pattern" >&2
-    exit 1
-  fi
-done
-
-required_powershell_gate_patterns=(
-  "Get-PlanImplementationSkeletonErrors"
-  "Resolve-PlanImplementationSection"
-  "Reference Snippets"
-  "组件职责与代码落点"
-  "blocking_findings"
-  "result=pass"
-  "result=fail"
-  "harness check passed"
-)
-
-for pattern in "${required_powershell_gate_patterns[@]}"; do
-  if ! rg -Fq "$pattern" scripts/harness/common.ps1 scripts/harness/review_gate.ps1 scripts/harness/check.ps1; then
-    echo "PowerShell harness gates missing required pattern: $pattern" >&2
-    exit 1
-  fi
-done
 
 optional_mode_files=(
   ".agents/prompts/orchestrator-thread.md"
@@ -538,17 +171,10 @@ optional_mode_files=(
 
 optional_bundle_files=(
   ".agents/prompts/README.md"
-  ".agents/prompts/orchestrator-thread.md"
-  ".agents/prompts/issue-standard-workflow.md"
-  ".agents/prompts/loop-codex.md"
-  ".agents/prompts/loop-automation.md"
-  ".agents/prompts/maintenance-loop.md"
-  ".agents/guides/code-review.md"
-  ".agents/guides/linter.md"
+  "${optional_mode_files[@]}"
 )
 
 has_optional_bundle=0
-
 for path in "${optional_bundle_files[@]}"; do
   if [[ -f "$path" ]]; then
     has_optional_bundle=1
@@ -558,660 +184,58 @@ done
 
 if [[ "$has_optional_bundle" -eq 1 ]]; then
   for path in "${optional_bundle_files[@]}"; do
-    if [[ ! -f "$path" ]]; then
-      echo "Optional agent extension bundle is incomplete: missing $path" >&2
-      exit 1
-    fi
+    [[ -f "$path" ]] || fail "Optional agent extension bundle is incomplete: missing $path"
   done
 
   detected_mode=""
   for path in "${optional_mode_files[@]}"; do
-    if ! rg -qx "Mode: (placeholder|full)" "$path"; then
-      echo "Optional harness file missing valid mode marker: $path" >&2
-      exit 1
-    fi
-
+    rg -qx "Mode: (placeholder|full)" "$path" \
+      || fail "Optional harness file missing valid mode marker: $path"
     current_mode="$(sed -n '1s/^Mode: //p' "$path")"
     if [[ -z "$detected_mode" ]]; then
       detected_mode="$current_mode"
     elif [[ "$detected_mode" != "$current_mode" ]]; then
-      echo "Optional agent extension bundle has mixed modes: expected $detected_mode, got $current_mode in $path" >&2
-      exit 1
+      fail "Optional agent extension bundle has mixed modes: expected $detected_mode, got $current_mode in $path"
     fi
   done
-
-  for pattern in "orchestrator-thread.md" "issue-standard-workflow.md" "loop-codex.md" "loop-automation.md" "maintenance-loop.md"; do
-    if ! rg -Fq "$pattern" ".agents/prompts/README.md"; then
-      echo ".agents/prompts/README.md missing prompt reference: $pattern" >&2
-      exit 1
-    fi
-  done
-
-  if ! rg -Fq "docs/harness/project-constraints.md" ".agents/guides/linter.md"; then
-    echo ".agents/guides/linter.md should point project-level mechanical constraints back to docs/harness/project-constraints.md" >&2
-    exit 1
-  fi
-
-  if [[ "$detected_mode" == "full" ]]; then
-    required_orchestrator_patterns=(
-      "goal-orchestration"
-      "write_lease"
-      "Current State"
-      "Thread Status"
-      "post-integration verify"
-      "waiting_on_child"
-      "【完成】"
-      "set_thread_title"
-    )
-
-    for pattern in "${required_orchestrator_patterns[@]}"; do
-      if ! rg -Fq "$pattern" ".agents/prompts/orchestrator-thread.md"; then
-        echo ".agents/prompts/orchestrator-thread.md missing required pattern: $pattern" >&2
-        exit 1
-      fi
-    done
-
-    required_issue_workflow_patterns=(
-      "真实入口与触发"
-      "输入装配与边界校验"
-      "组件职责与代码落点"
-      "关键执行时序"
-      "停止 / 错误 / 恢复"
-      "入口代码位置"
-      "装配结果 / 核心对象"
-      "步骤化时序"
-      "关键分支 / 降级路径"
-      "File Map"
-      "伪代码 / 主循环"
-      "关键分支与实现策略"
-      "竞态 / 状态机分析"
-      "不要用 harness 控制流图替代业务实现图"
-      "不要只画图，不写步骤化时序"
-      "不要只写职责，不写代码落点"
-      "不要只写 happy path，不写关键分支 / 降级路径"
-      "不要把 Concrete Steps 写成纯控制面收口步骤"
-      "orchestrator-thread.md"
-      "write_lease"
-      "post-integration verify"
-      "【完成】"
-    )
-
-    for pattern in "${required_issue_workflow_patterns[@]}"; do
-      if ! rg -Fq "$pattern" ".agents/prompts/issue-standard-workflow.md"; then
-        echo ".agents/prompts/issue-standard-workflow.md missing required pattern: $pattern" >&2
-        exit 1
-      fi
-    done
-
-    required_maintenance_patterns=(
-      "report-only"
-      "issue-create"
-      "safe-fix"
-      "rule-promotion"
-      "Maintenance Findings"
-      "Classification"
-      "Verification Plan"
-      "Writeback Plan"
-      "Residual Risks"
-      "Next Action"
-      "rule_promotion_candidate"
-      "human_decision_required"
-    )
-
-    for pattern in "${required_maintenance_patterns[@]}"; do
-      if ! rg -Fq "$pattern" ".agents/prompts/maintenance-loop.md"; then
-        echo ".agents/prompts/maintenance-loop.md missing required pattern: $pattern" >&2
-        exit 1
-      fi
-    done
-  fi
 fi
 
-tmp_plan_new="$(mktemp -t harness-plan-new)"
-tmp_plan_legacy="$(mktemp -t harness-plan-legacy)"
-tmp_bad_plan_no_steps="$(mktemp -t harness-plan-bad-steps)"
-tmp_bad_plan_no_core="$(mktemp -t harness-plan-bad-core)"
-tmp_bad_plan_no_branch="$(mktemp -t harness-plan-bad-branch)"
-tmp_bad_plan_no_snippets="$(mktemp -t harness-plan-bad-snippets)"
-tmp_bad_plan_no_component_row="$(mktemp -t harness-plan-bad-component-row)"
-tmp_bad_plan_harness_flow="$(mktemp -t harness-plan-bad-harness-flow)"
-trap 'rm -f "$tmp_plan_new" "$tmp_plan_legacy" "$tmp_bad_plan_no_steps" "$tmp_bad_plan_no_core" "$tmp_bad_plan_no_branch" "$tmp_bad_plan_no_snippets" "$tmp_bad_plan_no_component_row" "$tmp_bad_plan_harness_flow"' EXIT
-
-cat >"$tmp_plan_new" <<'EOF'
----
-name: harness smoke new
-overview: verify implementation-first plan shape
-todos:
-  - id: smoke
-    content: validate new review gate path
-    status: pending
-isProject: false
----
-
-# ExecPlan: harness smoke new
-
-## Goal
-- 目标：验证新模板风格的 plan 可以通过 review gate。
-- 成功标准：review gate 和 Makefile 入口都返回 pass。
-
-## Scope and Non-Goals
-- 本次范围：只验证结构与 gate。
-- 明确不做：不实现真实业务逻辑。
-
-## Scope Freeze
-
-| 类别 | 本次纳入 |
-| --- | --- |
-| gate smoke | `review_gate` 正反例 |
-
-| 类别 | 本次不纳入 |
-| --- | --- |
-| 代码实现 | 不写真实代码 |
-
-| 类别 | 验收口径 |
-| --- | --- |
-| gate | 新风格 plan 能通过 |
-
-## Context and Orientation
-
-- 当前仓库现状：只需要验证新模板 contract。
-- 关键入口文件 / 文档：`scripts/harness/review_gate.sh`
-- 可复用组件 / 已有能力：`common.sh`
-- 风险、依赖与未决项：无
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`make harness-review-gate`
-- `入口代码位置`：`scripts/harness/review_gate.sh`
-- `触发条件 / 上游依赖`：传入合法 plan 路径即可
-
-### 输入装配与边界校验
-- `输入来源`：CLI 参数 `--plan`
-- `装配位置`：`review_gate.sh`
-- `装配结果 / 核心对象`：待校验的 plan 文件路径
-- `边界校验`：plan 文件不存在时直接失败
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `scripts/harness/review_gate.sh` | 复用 | `review gate` | 读取 plan 并输出 pass / fail | 不负责实现业务逻辑 |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["make harness-review-gate"] --> Gate["review_gate.sh"]
-    Gate --> Result["pass/fail"]
-```
-- `图示说明`：Makefile 入口转到 review gate，读取 plan 后给出结论。
-- `步骤化时序`：
-  1. Makefile 接收 `PLAN` 参数。
-  2. review gate 读取 plan 并检查实现骨架。
-  3. blocking findings 为 none 时输出 pass。
-- `关键状态推进 / 数据流`：输入路径被解析为一个待校验 plan，最后输出 gate 结果。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：plan 通过校验并输出 pass。
-- `主要错误出口`：plan 缺字段或缺结构时输出 fail。
-- `关键分支 / 降级路径`：缺少实现骨架时立即失败，不继续读取 review 结果。
-- `恢复 / 重试 / 回滚`：补全 plan 后可安全重跑。
-
-## 1. Gate 合约 -- smoke 校验
-
-### 目标与边界
-- 目标：验证新风格 plan 可以过 gate。
-- 这一块明确不做什么：不引入新的 shell 接口。
-
-### 接口 / 结构目标形状
-
-```text
-make harness-review-gate PLAN=/tmp/example-plan.md
-```
-
-### 实现要点
-- 继续复用 `blocking_findings`
-- 兼容旧 `## Architecture / Data Flow`
-- 支持新 `## 0. 现有架构回顾与核心设计决策`
-
-### 验证关注点
-- 新风格通过
-- 旧风格仍通过
-
-## 数据流可视化
-
-```mermaid
-sequenceDiagram
-    participant Make as Make
-    participant Gate as review_gate
-    participant Plan as Plan
-
-    Make->>Gate: PLAN=/tmp/example-plan.md
-    Gate->>Plan: 读取内容
-    Gate-->>Make: result=pass
-```
-
-- `主路径说明`：参数被读取后转成 gate 判断。
-- `关键分支说明`：结构缺失则立即失败。
-
-## 关键设计决策摘要
-
-- `决策 1`：保留 `blocking_findings` 作为 review gate 输入。
-- `决策 2`：新旧 plan 标题都兼容。
-
-## 与现有代码的关系
-
-- `复用的现有能力`：Makefile 与 review gate 入口
-- `需要新增或改造的模块`：无
-- `明确不改的现有模块`：其余 harness 文件
-- `对外行为 / 接口 / 配置变化`：无
-
-## Reference Snippets
-
-```text
-result=pass
-blocking_findings=none
-plan=/tmp/example-plan.md
-```
-
-- `片段说明`：锁定 gate 成功时的最小输出形状。
-
-## Concrete Steps
-
-### 实现步骤
-1. 读取 plan。
-2. 校验实现骨架。
-
-## Review Summary
-- `blocking_findings`: none
-EOF
-
-cat >"$tmp_plan_legacy" <<'EOF'
-# ExecPlan: harness smoke legacy
-
-## Architecture / Data Flow
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：`SmokeRunnerConfig`
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `internal/demo/runner.go` | 新增 | `SmokeRunner` | 串接 smoke runner 并返回结果 | 不负责网络重试 |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["CLI"] --> Runner["SmokeRunner"]
-```
-- `图示说明`：CLI 触发 smoke runner。
-- `步骤化时序`：
-  1. root command 解析参数并构造 config。
-  2. runner 消费 config 并返回结果摘要。
-- `关键状态推进 / 数据流`：输入参数归一化后进入 runner。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：无 pipeline 时降级为失败返回，不启动 runner。
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-```text
-SmokeRunnerConfig{Pipeline: "smoke"}
-```
-
-- `片段说明`：锁定 smoke runner 的最小输入对象。
-
-## Concrete Steps
-
-### 实现步骤
-1. 编写 smoke runner。
-
-## Review Summary
-- `blocking_findings`: none
-EOF
-
-cat >"$tmp_bad_plan_no_steps" <<'EOF'
-# ExecPlan: harness smoke bad no steps
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：`SmokeRunnerConfig`
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `internal/demo/runner.go` | 新增 | `SmokeRunner` | 串接 smoke runner 并返回结果 | 不负责网络重试 |
-
-```mermaid
-flowchart TD
-    Entry["CLI"] --> Runner["SmokeRunner"]
-```
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：无 pipeline 时降级为失败返回，不启动 runner。
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-```text
-SmokeRunnerConfig{Pipeline: "smoke"}
-```
-
-- `片段说明`：锁定 smoke runner 的最小输入对象。
-
-## Concrete Steps
-
-### 实现步骤
-1. verify
-
-## Review Summary
-- `blocking_findings`: none
-EOF
-
-cat >"$tmp_bad_plan_no_core" <<'EOF'
-# ExecPlan: harness smoke bad no core object
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `internal/demo/runner.go` | 新增 | `SmokeRunner` | 串接 smoke runner 并返回结果 | 不负责网络重试 |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["CLI"] --> Runner["SmokeRunner"]
-```
-- `图示说明`：CLI 触发 smoke runner。
-- `步骤化时序`：
-  1. root command 解析参数并构造 config。
-  2. runner 消费 config 并返回结果摘要。
-- `关键状态推进 / 数据流`：输入参数归一化后进入 runner。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：无 pipeline 时降级为失败返回，不启动 runner。
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-```text
-SmokeRunnerConfig{Pipeline: "smoke"}
-```
-
-- `片段说明`：锁定 smoke runner 的最小输入对象。
-
-## Concrete Steps
-
-### 实现步骤
-1. 编写 smoke runner。
-
-## Review Summary
-- `blocking_findings`: none
-EOF
-
-cat >"$tmp_bad_plan_no_branch" <<'EOF'
-# ExecPlan: harness smoke bad no branch
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：`SmokeRunnerConfig`
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `internal/demo/runner.go` | 新增 | `SmokeRunner` | 串接 smoke runner 并返回结果 | 不负责网络重试 |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["CLI"] --> Runner["SmokeRunner"]
-```
-- `图示说明`：CLI 触发 smoke runner。
-- `步骤化时序`：
-  1. root command 解析参数并构造 config。
-  2. runner 消费 config 并返回结果摘要。
-- `关键状态推进 / 数据流`：输入参数归一化后进入 runner。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-```text
-SmokeRunnerConfig{Pipeline: "smoke"}
-```
-
-- `片段说明`：锁定 smoke runner 的最小输入对象。
-
-## Concrete Steps
-
-### 实现步骤
-1. 编写 smoke runner。
-
-## Review Summary
-- `blocking_findings`: none
-EOF
-
-cat >"$tmp_bad_plan_no_snippets" <<'EOF'
-# ExecPlan: harness smoke bad no snippets
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：`SmokeRunnerConfig`
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-| `internal/demo/runner.go` | 新增 | `SmokeRunner` | 串接 smoke runner 并返回结果 | 不负责网络重试 |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["CLI"] --> Runner["SmokeRunner"]
-```
-- `图示说明`：CLI 触发 smoke runner。
-- `步骤化时序`：
-  1. root command 解析参数并构造 config。
-  2. runner 消费 config 并返回结果摘要。
-- `关键状态推进 / 数据流`：输入参数归一化后进入 runner。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：无 pipeline 时降级为失败返回，不启动 runner。
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-## Concrete Steps
-
-### 实现步骤
-1. 编写 smoke runner。
-
-## Review Summary
-- `blocking_findings`: none
-EOF
-
-cat >"$tmp_bad_plan_no_component_row" <<'EOF'
-# ExecPlan: harness smoke bad no component row
-
-## 0. 现有架构回顾与核心设计决策
-
-### 真实入口与触发
-- `入口命令 / 调用源`：`cmd/demo`
-- `入口代码位置`：`cmd/demo/root.go`
-- `触发条件 / 上游依赖`：CLI 完成解析后进入 smoke runner。
-
-### 输入装配与边界校验
-- `输入来源`：CLI flags
-- `装配位置`：`cmd/demo/root.go`
-- `装配结果 / 核心对象`：`SmokeRunnerConfig`
-- `边界校验`：缺少 pipeline 时直接失败。
-
-### 组件职责与代码落点
-| 模块/类型 | 新增/复用 | 关键产物 | 职责 | 不负责 |
-| --- | --- | --- | --- | --- |
-
-### 关键执行时序
-```mermaid
-flowchart TD
-    Entry["CLI"] --> Runner["SmokeRunner"]
-```
-- `图示说明`：CLI 触发 smoke runner。
-- `步骤化时序`：
-  1. root command 解析参数并构造 config。
-  2. runner 消费 config 并返回结果摘要。
-- `关键状态推进 / 数据流`：输入参数归一化后进入 runner。
-
-### 停止 / 错误 / 恢复
-- `正常停止条件`：runner 返回结果。
-- `主要错误出口`：参数缺失时直接返回错误。
-- `关键分支 / 降级路径`：无 pipeline 时降级为失败返回，不启动 runner。
-- `恢复 / 重试 / 回滚`：修正参数后可安全重跑。
-
-## Reference Snippets
-
-```text
-SmokeRunnerConfig{Pipeline: "smoke"}
-```
-
-- `片段说明`：锁定 smoke runner 的最小输入对象。
-
-## Concrete Steps
-
-### 实现步骤
-1. 编写 smoke runner。
-
-## Review Summary
-- `blocking_findings`: none
-EOF
-
-cat >"$tmp_bad_plan_harness_flow" <<'EOF'
-# ExecPlan: harness smoke bad harness flow
-
-## Architecture / Data Flow
-
-```mermaid
-flowchart TD
-    Collect["collect"] --> Verify["verify"]
-    Verify --> Review["review"]
-    Review --> Notify["notify"]
-```
-
-## Reference Snippets
-
-```text
-result=pass
-```
-
-## Concrete Steps
-
-### 实现步骤
-1. 运行控制面。
-
-## Review Summary
-- `blocking_findings`: none
-EOF
-
-if ! bash scripts/harness/review_gate.sh --plan "$tmp_plan_new" >/dev/null; then
-  echo "review_gate should pass for a new implementation-first plan" >&2
-  exit 1
+bash -n scripts/harness/common.sh scripts/harness/review_gate.sh scripts/harness/evidence.sh
+
+tmp_plan="$(mktemp -t harness-plan-pass)"
+tmp_blocking_plan="$(mktemp -t harness-plan-blocking)"
+tmp_evidence_repo="$(mktemp -d -t harness-evidence-smoke)"
+trap 'rm -f "$tmp_plan" "$tmp_blocking_plan"; rm -rf "$tmp_evidence_repo"' EXIT
+
+cp .agents/plans/EXAMPLE-implementation.md "$tmp_plan"
+cp "$tmp_plan" "$tmp_blocking_plan"
+perl -0pi -e 's/`blocking_findings`: none/`blocking_findings`: correctness regression/' "$tmp_blocking_plan"
+
+if ! bash scripts/harness/review_gate.sh --plan "$tmp_plan" >/dev/null; then
+  fail "review gate should pass for the implementation example"
+fi
+if bash scripts/harness/review_gate.sh --plan "$tmp_blocking_plan" >/dev/null 2>&1; then
+  fail "review gate should fail when blocking findings are present"
 fi
 
-if ! make harness-review-gate PLAN="$tmp_plan_new" >/dev/null; then
-  echo "Makefile harness-review-gate smoke test failed for the new plan shape" >&2
-  exit 1
-fi
+git init -q "$tmp_evidence_repo"
+git -C "$tmp_evidence_repo" config user.name "Harness Check"
+git -C "$tmp_evidence_repo" config user.email "harness-check@example.invalid"
+printf 'base\n' >"$tmp_evidence_repo/value.txt"
+git -C "$tmp_evidence_repo" add value.txt
+git -C "$tmp_evidence_repo" commit -qm "test: evidence base"
 
-if ! bash scripts/harness/review_gate.sh --plan "$tmp_plan_legacy" >/dev/null; then
-  echo "review_gate should still pass for a legacy plan without frontmatter" >&2
-  exit 1
-fi
+evidence_first="$(cd "$tmp_evidence_repo" && bash "$repo_root/scripts/harness/evidence.sh" snapshot)"
+evidence_second="$(cd "$tmp_evidence_repo" && bash "$repo_root/scripts/harness/evidence.sh" snapshot)"
+first_id="$(printf '%s\n' "$evidence_first" | sed -n 's/^evidence_id=//p')"
+second_id="$(printf '%s\n' "$evidence_second" | sed -n 's/^evidence_id=//p')"
+[[ -n "$first_id" && "$first_id" == "$second_id" ]] \
+  || fail "evidence helper should be stable for an unchanged repository"
 
-if bash scripts/harness/review_gate.sh --plan "$tmp_bad_plan_no_steps" >/dev/null 2>&1; then
-  echo "review_gate should fail for a plan without step-by-step flow" >&2
-  exit 1
-fi
-
-if bash scripts/harness/review_gate.sh --plan "$tmp_bad_plan_no_core" >/dev/null 2>&1; then
-  echo "review_gate should fail for a plan without core object/result" >&2
-  exit 1
-fi
-
-if bash scripts/harness/review_gate.sh --plan "$tmp_bad_plan_no_branch" >/dev/null 2>&1; then
-  echo "review_gate should fail for a plan without key branch/degrade path" >&2
-  exit 1
-fi
-
-if bash scripts/harness/review_gate.sh --plan "$tmp_bad_plan_no_snippets" >/dev/null 2>&1; then
-  echo "review_gate should fail for a plan without reference snippets" >&2
-  exit 1
-fi
-
-if bash scripts/harness/review_gate.sh --plan "$tmp_bad_plan_no_component_row" >/dev/null 2>&1; then
-  echo "review_gate should fail for a plan without a real component responsibility entry" >&2
-  exit 1
-fi
-
-if bash scripts/harness/review_gate.sh --plan "$tmp_bad_plan_harness_flow" >/dev/null 2>&1; then
-  echo "review_gate should fail for a plan that only contains harness flow" >&2
-  exit 1
-fi
+printf 'changed\n' >>"$tmp_evidence_repo/value.txt"
+evidence_changed="$(cd "$tmp_evidence_repo" && bash "$repo_root/scripts/harness/evidence.sh" snapshot)"
+changed_id="$(printf '%s\n' "$evidence_changed" | sed -n 's/^evidence_id=//p')"
+[[ -n "$changed_id" && "$changed_id" != "$first_id" ]] \
+  || fail "evidence helper should change after repository content changes"
 
 echo "harness check passed"

--- a/template/scripts/harness/evidence.ps1
+++ b/template/scripts/harness/evidence.ps1
@@ -1,0 +1,177 @@
+[CmdletBinding()]
+param(
+    [string]$Action = "Snapshot"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Canonical Git inputs: git diff --binary --no-ext-diff, git ls-files --others --exclude-standard -z,
+# git ls-files -u, git ls-files -v, and git submodule status/foreach.
+
+function Write-SnapshotResult {
+    param(
+        [Parameter(Mandatory=$true)][string]$Result,
+        [Parameter(Mandatory=$true)][string]$Head,
+        [Parameter(Mandatory=$true)][string]$WorktreeDigest,
+        [Parameter(Mandatory=$true)][string]$EvidenceId,
+        [Parameter(Mandatory=$true)][string]$Reusable,
+        [Parameter(Mandatory=$true)][string]$Reason
+    )
+
+    Write-Output "result=$Result"
+    Write-Output "head=$Head"
+    Write-Output "worktree_digest=$WorktreeDigest"
+    Write-Output "evidence_id=$EvidenceId"
+    Write-Output "reusable=$Reusable"
+    Write-Output "reason=$Reason"
+}
+
+function Invoke-GitLines {
+    param([Parameter(Mandatory=$true)][string[]]$Arguments)
+
+    $lines = @(& git @Arguments 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+    }
+    return $lines
+}
+
+function Get-UntrackedBlobHash {
+    param([Parameter(Mandatory=$true)][string]$Path)
+
+    $item = Get-Item -LiteralPath $Path -Force
+    $linkProperty = $item.PSObject.Properties["LinkTarget"]
+    if ($null -eq $linkProperty -or $null -eq $linkProperty.Value) {
+        $linkProperty = $item.PSObject.Properties["Target"]
+    }
+
+    if ($null -ne $linkProperty -and $null -ne $linkProperty.Value) {
+        $linkTarget = [string](@($linkProperty.Value) | Select-Object -First 1)
+        $linkInput = [System.IO.Path]::GetTempFileName()
+        try {
+            [System.IO.File]::WriteAllText($linkInput, $linkTarget, $utf8NoBom)
+            return (Invoke-GitLines -Arguments @("hash-object", $linkInput) | Select-Object -First 1)
+        } finally {
+            Remove-Item -LiteralPath $linkInput -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    return (Invoke-GitLines -Arguments @("hash-object", "--", $Path) | Select-Object -First 1)
+}
+
+if ($Action -ine "Snapshot") {
+    Write-SnapshotResult -Result "error" -Head "UNKNOWN" -WorktreeDigest "UNKNOWN" `
+        -EvidenceId "UNKNOWN" -Reusable "false" -Reason "unsupported_action"
+    exit 2
+}
+
+try {
+    $repoRoot = (Invoke-GitLines -Arguments @("rev-parse", "--show-toplevel") | Select-Object -First 1)
+} catch {
+    Write-SnapshotResult -Result "error" -Head "UNKNOWN" -WorktreeDigest "UNKNOWN" `
+        -EvidenceId "UNKNOWN" -Reusable "false" -Reason "not_git_repository"
+    exit 1
+}
+
+Push-Location $repoRoot
+$snapshotFile = [System.IO.Path]::GetTempFileName()
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+
+try {
+    try {
+        $headCommit = (Invoke-GitLines -Arguments @("rev-parse", "--verify", "HEAD") | Select-Object -First 1)
+        $diffBase = $headCommit
+    } catch {
+        $headCommit = "UNBORN"
+        $diffBase = ""
+    }
+
+    if ($headCommit -eq "UNBORN") {
+        $emptyTreeInput = [System.IO.Path]::GetTempFileName()
+        try {
+            [System.IO.File]::WriteAllBytes($emptyTreeInput, [byte[]]@())
+            $diffBase = (Invoke-GitLines -Arguments @("hash-object", "-t", "tree", $emptyTreeInput) | Select-Object -First 1)
+        } finally {
+            Remove-Item -LiteralPath $emptyTreeInput -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    $builder = New-Object System.Text.StringBuilder
+    [void]$builder.Append("head`0$headCommit`0")
+
+    [void]$builder.Append("index`0")
+    $indexDiffLines = Invoke-GitLines -Arguments @("diff", "--binary", "--no-ext-diff", "--cached", $diffBase, "--")
+    if ($indexDiffLines.Count -gt 0) {
+        [void]$builder.Append(($indexDiffLines -join "`n"))
+        [void]$builder.Append("`n")
+    }
+
+    [void]$builder.Append("worktree`0")
+    $worktreeDiffLines = Invoke-GitLines -Arguments @("diff", "--binary", "--no-ext-diff", "--")
+    if ($worktreeDiffLines.Count -gt 0) {
+        [void]$builder.Append(($worktreeDiffLines -join "`n"))
+        [void]$builder.Append("`n")
+    }
+
+    $untrackedRaw = (Invoke-GitLines -Arguments @("ls-files", "--others", "--exclude-standard", "-z")) -join "`n"
+    foreach ($path in $untrackedRaw.Split([char]0, [System.StringSplitOptions]::RemoveEmptyEntries)) {
+        $blobHash = Get-UntrackedBlobHash -Path $path
+        [void]$builder.Append("untracked`0$path`0$blobHash`0")
+    }
+
+    $submoduleSnapshot = Invoke-GitLines -Arguments @("submodule", "status", "--recursive")
+    [void]$builder.Append("submodules`0")
+    if ($submoduleSnapshot.Count -gt 0) {
+        [void]$builder.Append(($submoduleSnapshot -join "`n"))
+    }
+    [void]$builder.Append("`0")
+
+    [System.IO.File]::WriteAllText($snapshotFile, $builder.ToString(), $utf8NoBom)
+    $worktreeDigest = (Invoke-GitLines -Arguments @("hash-object", $snapshotFile) | Select-Object -First 1)
+
+    $evidenceInput = [System.IO.Path]::GetTempFileName()
+    try {
+        [System.IO.File]::WriteAllText($evidenceInput, "$headCommit`n$worktreeDigest`n", $utf8NoBom)
+        $evidenceId = (Invoke-GitLines -Arguments @("hash-object", $evidenceInput) | Select-Object -First 1)
+    } finally {
+        Remove-Item -LiteralPath $evidenceInput -Force -ErrorAction SilentlyContinue
+    }
+
+    $reusable = "true"
+    $reason = "snapshot_stable"
+    $unmerged = Invoke-GitLines -Arguments @("ls-files", "-u")
+
+    if ($unmerged.Count -gt 0) {
+        $reusable = "false"
+        $reason = "unmerged_entries"
+    } else {
+        $indexVisibility = Invoke-GitLines -Arguments @("ls-files", "-v")
+        if ($indexVisibility | Where-Object { $_ -match '^[a-zS]' }) {
+            $reusable = "false"
+            $reason = "index_visibility_flags"
+        } else {
+            $submoduleStatus = @(& git submodule status --recursive 2>$null)
+            if ($LASTEXITCODE -ne 0 -or ($submoduleStatus | Where-Object { $_ -match '^[+\-U]' })) {
+                $reusable = "false"
+                $reason = "dirty_or_unavailable_submodule"
+            } else {
+                & git submodule foreach --quiet --recursive 'test -z "$(git status --porcelain --untracked-files=normal)"' *> $null
+                if ($LASTEXITCODE -ne 0) {
+                    $reusable = "false"
+                    $reason = "dirty_or_unavailable_submodule"
+                }
+            }
+        }
+    }
+
+    Write-SnapshotResult -Result "ok" -Head $headCommit -WorktreeDigest $worktreeDigest `
+        -EvidenceId $evidenceId -Reusable $reusable -Reason $reason
+} catch {
+    Write-SnapshotResult -Result "error" -Head $(if ($headCommit) { $headCommit } else { "UNKNOWN" }) `
+        -WorktreeDigest "UNKNOWN" -EvidenceId "UNKNOWN" -Reusable "false" -Reason "snapshot_failed"
+    [Console]::Error.WriteLine($_.Exception.Message)
+    exit 1
+} finally {
+    Remove-Item -LiteralPath $snapshotFile -Force -ErrorAction SilentlyContinue
+    Pop-Location
+}

--- a/template/scripts/harness/evidence.sh
+++ b/template/scripts/harness/evidence.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+action="${1:-snapshot}"
+
+emit_snapshot() {
+  local result="$1"
+  local head="$2"
+  local worktree_digest="$3"
+  local evidence_id="$4"
+  local reusable="$5"
+  local reason="$6"
+
+  printf 'result=%s\n' "$result"
+  printf 'head=%s\n' "$head"
+  printf 'worktree_digest=%s\n' "$worktree_digest"
+  printf 'evidence_id=%s\n' "$evidence_id"
+  printf 'reusable=%s\n' "$reusable"
+  printf 'reason=%s\n' "$reason"
+}
+
+if [[ "$action" != "snapshot" ]]; then
+  emit_snapshot "error" "UNKNOWN" "UNKNOWN" "UNKNOWN" "false" "unsupported_action"
+  exit 2
+fi
+
+if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  emit_snapshot "error" "UNKNOWN" "UNKNOWN" "UNKNOWN" "false" "not_git_repository"
+  exit 1
+fi
+
+cd "$repo_root"
+
+if head_commit="$(git rev-parse --verify HEAD 2>/dev/null)"; then
+  diff_base="$head_commit"
+else
+  head_commit="UNBORN"
+  diff_base="$(git hash-object -t tree /dev/null)"
+fi
+
+snapshot_file="$(mktemp -t harness-evidence-snapshot)"
+untracked_file="$(mktemp -t harness-evidence-untracked)"
+trap 'rm -f "$snapshot_file" "$untracked_file"' EXIT
+
+if ! git ls-files --others --exclude-standard -z >"$untracked_file"; then
+  emit_snapshot "error" "$head_commit" "UNKNOWN" "UNKNOWN" "false" "snapshot_failed"
+  exit 1
+fi
+
+write_snapshot_payload() {
+  local path
+  local blob_hash
+  local submodule_status
+
+  printf 'head\0%s\0' "$head_commit"
+
+  printf 'index\0'
+  if ! git diff --binary --no-ext-diff --cached "$diff_base" --; then
+    return 1
+  fi
+
+  printf 'worktree\0'
+  if ! git diff --binary --no-ext-diff --; then
+    return 1
+  fi
+
+  while IFS= read -r -d '' path; do
+    if [[ -L "$path" ]]; then
+      if ! blob_hash="$(readlink -n -- "$path" | git hash-object --stdin)"; then
+        return 1
+      fi
+    elif ! blob_hash="$(git hash-object -- "$path")"; then
+      return 1
+    fi
+    printf 'untracked\0%s\0%s\0' "$path" "$blob_hash"
+  done <"$untracked_file"
+
+  if ! submodule_status="$(git submodule status --recursive 2>/dev/null)"; then
+    return 1
+  fi
+  printf 'submodules\0%s\0' "$submodule_status"
+}
+
+if ! write_snapshot_payload >"$snapshot_file"; then
+  emit_snapshot "error" "$head_commit" "UNKNOWN" "UNKNOWN" "false" "snapshot_failed"
+  exit 1
+fi
+
+worktree_digest="$(git hash-object "$snapshot_file")"
+evidence_id="$(printf '%s\n%s\n' "$head_commit" "$worktree_digest" | git hash-object --stdin)"
+reusable="true"
+reason="snapshot_stable"
+index_visibility=""
+
+if [[ -n "$(git ls-files -u)" ]]; then
+  reusable="false"
+  reason="unmerged_entries"
+elif ! index_visibility="$(git ls-files -v)"; then
+  reusable="false"
+  reason="snapshot_failed"
+elif printf '%s\n' "$index_visibility" | grep -Eq '^[a-zS]'; then
+  reusable="false"
+  reason="index_visibility_flags"
+elif git submodule status --recursive 2>/dev/null | grep -Eq '^[+-U]'; then
+  reusable="false"
+  reason="dirty_or_unavailable_submodule"
+elif ! git submodule foreach --quiet --recursive \
+  'test -z "$(git status --porcelain --untracked-files=normal)"' >/dev/null 2>&1; then
+  reusable="false"
+  reason="dirty_or_unavailable_submodule"
+fi
+
+emit_snapshot "ok" "$head_commit" "$worktree_digest" "$evidence_id" "$reusable" "$reason"

--- a/tests/evidence_helper_test.sh
+++ b/tests/evidence_helper_test.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+helper="$repo_root/template/scripts/harness/evidence.sh"
+powershell_helper="$repo_root/template/scripts/harness/evidence.ps1"
+
+fail() {
+  echo "evidence helper test: $*" >&2
+  exit 1
+}
+
+field() {
+  local output="$1"
+  local name="$2"
+
+  printf '%s\n' "$output" | sed -n "s/^${name}=//p" | head -n 1
+}
+
+new_repo() {
+  local path="$1"
+
+  git init -q "$path"
+  git -C "$path" config user.name "Harness Test"
+  git -C "$path" config user.email "harness-test@example.invalid"
+}
+
+snapshot() {
+  local path="$1"
+  (cd "$path" && bash "$helper" snapshot)
+}
+
+if [[ ! -f "$helper" ]]; then
+  fail "missing helper: $helper"
+fi
+
+set +e
+unsupported_output="$(bash "$helper" unsupported 2>/dev/null)"
+unsupported_status=$?
+set -e
+[[ "$unsupported_status" -eq 2 ]] || fail "unsupported action should exit 2"
+[[ "$(field "$unsupported_output" reusable)" == "false" ]] \
+  || fail "unsupported action must not return reusable evidence"
+[[ "$(field "$unsupported_output" reason)" == "unsupported_action" ]] \
+  || fail "unsupported action should report unsupported_action"
+
+tmp_root="$(mktemp -d -t harness-evidence-test)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+repo="$tmp_root/repo"
+new_repo "$repo"
+printf 'base\n' >"$repo/tracked.txt"
+git -C "$repo" add tracked.txt
+git -C "$repo" commit -qm "test: base"
+
+clean_first="$(snapshot "$repo")"
+clean_second="$(snapshot "$repo")"
+
+[[ "$(field "$clean_first" result)" == "ok" ]] || fail "clean snapshot should succeed"
+[[ "$(field "$clean_first" reusable)" == "true" ]] || fail "clean snapshot should be reusable"
+[[ -n "$(field "$clean_first" head)" ]] || fail "clean snapshot should include head"
+[[ -n "$(field "$clean_first" worktree_digest)" ]] || fail "clean snapshot should include worktree_digest"
+[[ "$(field "$clean_first" evidence_id)" == "$(field "$clean_second" evidence_id)" ]] \
+  || fail "same repository state should produce the same evidence_id"
+
+visibility_repo="$tmp_root/index-visibility"
+new_repo "$visibility_repo"
+printf 'base\n' >"$visibility_repo/tracked.txt"
+git -C "$visibility_repo" add tracked.txt
+git -C "$visibility_repo" commit -qm "test: visibility base"
+
+git -C "$visibility_repo" update-index --assume-unchanged tracked.txt
+printf 'hidden change\n' >>"$visibility_repo/tracked.txt"
+assume_unchanged_snapshot="$(snapshot "$visibility_repo")"
+[[ "$(field "$assume_unchanged_snapshot" reusable)" == "false" ]] \
+  || fail "assume-unchanged paths must disable evidence reuse"
+[[ "$(field "$assume_unchanged_snapshot" reason)" == "index_visibility_flags" ]] \
+  || fail "assume-unchanged paths should report index_visibility_flags"
+git -C "$visibility_repo" update-index --no-assume-unchanged tracked.txt
+git -C "$visibility_repo" reset -q --hard HEAD
+
+git -C "$visibility_repo" update-index --skip-worktree tracked.txt
+printf 'hidden change\n' >>"$visibility_repo/tracked.txt"
+skip_worktree_snapshot="$(snapshot "$visibility_repo")"
+[[ "$(field "$skip_worktree_snapshot" reusable)" == "false" ]] \
+  || fail "skip-worktree paths must disable evidence reuse"
+[[ "$(field "$skip_worktree_snapshot" reason)" == "index_visibility_flags" ]] \
+  || fail "skip-worktree paths should report index_visibility_flags"
+git -C "$visibility_repo" update-index --no-skip-worktree tracked.txt
+
+symlink_repo="$tmp_root/symlink"
+new_repo "$symlink_repo"
+printf 'target-*\n' >"$symlink_repo/.gitignore"
+printf 'same content\n' >"$symlink_repo/target-one"
+printf 'same content\n' >"$symlink_repo/target-two"
+ln -s target-one "$symlink_repo/link"
+symlink_first="$(snapshot "$symlink_repo")"
+unlink "$symlink_repo/link"
+ln -s target-two "$symlink_repo/link"
+symlink_second="$(snapshot "$symlink_repo")"
+[[ "$(field "$symlink_first" evidence_id)" != "$(field "$symlink_second" evidence_id)" ]] \
+  || fail "untracked symlink retargeting must invalidate evidence_id"
+
+printf 'changed\n' >>"$repo/tracked.txt"
+tracked_change="$(snapshot "$repo")"
+
+[[ "$(field "$tracked_change" evidence_id)" != "$(field "$clean_first" evidence_id)" ]] \
+  || fail "tracked content changes should invalidate evidence_id"
+
+git -C "$repo" add tracked.txt
+staged_change="$(snapshot "$repo")"
+[[ "$(field "$staged_change" evidence_id)" != "$(field "$clean_first" evidence_id)" ]] \
+  || fail "staged content changes should invalidate evidence_id"
+
+printf 'base\n' >"$repo/tracked.txt"
+staged_then_reverted_worktree="$(snapshot "$repo")"
+[[ "$(field "$staged_then_reverted_worktree" evidence_id)" != "$(field "$clean_first" evidence_id)" ]] \
+  || fail "staged changes must remain visible when an unstaged edit restores the HEAD content"
+
+git -C "$repo" reset -q --hard HEAD
+printf 'new\n' >"$repo/new file.txt"
+untracked_change="$(snapshot "$repo")"
+[[ "$(field "$untracked_change" evidence_id)" != "$(field "$clean_first" evidence_id)" ]] \
+  || fail "untracked content should invalidate evidence_id"
+
+printf 'newer\n' >>"$repo/new file.txt"
+untracked_content_change="$(snapshot "$repo")"
+[[ "$(field "$untracked_content_change" evidence_id)" != "$(field "$untracked_change" evidence_id)" ]] \
+  || fail "untracked content changes should invalidate evidence_id"
+
+printf 'unreadable\n' >"$repo/unreadable.txt"
+chmod 000 "$repo/unreadable.txt"
+set +e
+unreadable_snapshot="$(snapshot "$repo" 2>/dev/null)"
+unreadable_status=$?
+set -e
+chmod 600 "$repo/unreadable.txt"
+rm -f "$repo/unreadable.txt"
+[[ "$unreadable_status" -ne 0 ]] || fail "unreadable files should fail snapshot calculation"
+[[ "$(field "$unreadable_snapshot" reusable)" == "false" ]] \
+  || fail "unreadable files must not produce reusable evidence"
+[[ "$(field "$unreadable_snapshot" reason)" == "snapshot_failed" ]] \
+  || fail "unreadable files should report snapshot_failed"
+
+rm -f "$repo/new file.txt"
+rm -f "$repo/tracked.txt"
+deleted_change="$(snapshot "$repo")"
+[[ "$(field "$deleted_change" evidence_id)" != "$(field "$clean_first" evidence_id)" ]] \
+  || fail "deleted tracked files should invalidate evidence_id"
+
+git -C "$repo" reset -q --hard HEAD
+git -C "$repo" mv tracked.txt renamed.txt
+renamed_change="$(snapshot "$repo")"
+[[ "$(field "$renamed_change" evidence_id)" != "$(field "$clean_first" evidence_id)" ]] \
+  || fail "renamed tracked files should invalidate evidence_id"
+
+unborn_repo="$tmp_root/unborn"
+new_repo "$unborn_repo"
+printf 'first\n' >"$unborn_repo/untracked.txt"
+unborn_first="$(snapshot "$unborn_repo")"
+printf 'second\n' >>"$unborn_repo/untracked.txt"
+unborn_second="$(snapshot "$unborn_repo")"
+
+[[ "$(field "$unborn_first" head)" == "UNBORN" ]] || fail "unborn repository should use UNBORN head"
+[[ "$(field "$unborn_first" evidence_id)" != "$(field "$unborn_second" evidence_id)" ]] \
+  || fail "unborn untracked content changes should invalidate evidence_id"
+
+conflict_repo="$tmp_root/conflict"
+new_repo "$conflict_repo"
+printf 'base\n' >"$conflict_repo/conflict.txt"
+git -C "$conflict_repo" add conflict.txt
+git -C "$conflict_repo" commit -qm "test: conflict base"
+git -C "$conflict_repo" switch -qc other
+printf 'other\n' >"$conflict_repo/conflict.txt"
+git -C "$conflict_repo" commit -qam "test: other change"
+git -C "$conflict_repo" switch -q master
+printf 'main\n' >"$conflict_repo/conflict.txt"
+git -C "$conflict_repo" commit -qam "test: main change"
+if git -C "$conflict_repo" merge other >/dev/null 2>&1; then
+  fail "conflict fixture should not merge cleanly"
+fi
+
+conflict_snapshot="$(snapshot "$conflict_repo")"
+[[ "$(field "$conflict_snapshot" result)" == "ok" ]] || fail "conflict snapshot should still be readable"
+[[ "$(field "$conflict_snapshot" reusable)" == "false" ]] || fail "unmerged entries must not be reusable"
+[[ "$(field "$conflict_snapshot" reason)" == "unmerged_entries" ]] \
+  || fail "unmerged entries should report a stable reason"
+
+submodule_origin="$tmp_root/submodule-origin"
+new_repo "$submodule_origin"
+printf 'submodule\n' >"$submodule_origin/value.txt"
+git -C "$submodule_origin" add value.txt
+git -C "$submodule_origin" commit -qm "test: submodule base"
+
+submodule_repo="$tmp_root/submodule-repo"
+new_repo "$submodule_repo"
+printf 'root\n' >"$submodule_repo/root.txt"
+git -C "$submodule_repo" add root.txt
+git -C "$submodule_repo" commit -qm "test: root base"
+git -C "$submodule_repo" -c protocol.file.allow=always submodule add -q "$submodule_origin" deps/sub
+git -C "$submodule_repo" commit -qam "test: add submodule"
+printf 'dirty\n' >>"$submodule_repo/deps/sub/value.txt"
+
+submodule_snapshot="$(snapshot "$submodule_repo")"
+[[ "$(field "$submodule_snapshot" result)" == "ok" ]] || fail "dirty submodule snapshot should be readable"
+[[ "$(field "$submodule_snapshot" reusable)" == "false" ]] || fail "dirty submodules must not be reusable"
+[[ "$(field "$submodule_snapshot" reason)" == "dirty_or_unavailable_submodule" ]] \
+  || fail "dirty submodules should report a stable reason"
+
+[[ -f "$powershell_helper" ]] || fail "missing PowerShell helper: $powershell_helper"
+for pattern in \
+  'Action = "Snapshot"' \
+  'result=' \
+  'head=' \
+  'worktree_digest=' \
+  'evidence_id=' \
+  'reusable=' \
+  'reason=' \
+  'unsupported_action' \
+  'git diff --binary --no-ext-diff' \
+  '"--cached"' \
+  '"worktree`0"' \
+  'git ls-files --others --exclude-standard -z' \
+  'git ls-files -u' \
+  'git submodule' \
+  '"submodules`0"'; do
+  rg -Fq -- "$pattern" "$powershell_helper" \
+    || fail "PowerShell helper missing contract pattern: $pattern"
+done
+for pattern in \
+  'index_visibility_flags' \
+  'git ls-files -v' \
+  'LinkTarget'; do
+  rg -Fq -- "$pattern" "$powershell_helper" \
+    || fail "PowerShell helper missing conservative visibility/symlink contract: $pattern"
+done
+if rg -Fq 'Get-Item -LiteralPath $null' "$powershell_helper"; then
+  fail "PowerShell unborn branch setup must not pass a null path to git hash-object"
+fi
+
+echo "evidence helper tests passed"

--- a/tests/policy_contract_test.sh
+++ b/tests/policy_contract_test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  echo "policy contract test: $*" >&2
+  exit 1
+}
+
+assert_patterns() {
+  local path="$1"
+  shift
+  local pattern
+
+  [[ -f "$path" ]] || fail "missing policy source: ${path#$repo_root/}"
+  for pattern in "$@"; do
+    rg -Fq -- "$pattern" "$path" \
+      || fail "${path#$repo_root/} missing policy contract: $pattern"
+  done
+}
+
+control_plane="$repo_root/template/docs/harness/control-plane.md"
+assert_patterns "$control_plane" \
+  "Review Policy Contract" \
+  '`review_policy`: `standard` / `strict`' \
+  '`standard` 允许主 agent 执行对抗式自审' \
+  '`strict` 必须由 subagent 独立评审' \
+  '`blocked: subagent_review_unavailable`' \
+  '调用方未提供 `review_policy` 时按 `strict` 处理' \
+  "多仓代码改动、多个可写 lease 或 branch / worktree 集成" \
+  "鉴权、安全、权限、公开 API 或 contract 兼容性" \
+  "schema、migration 或数据修改" \
+  "并发、幂等、重试或业务状态机" \
+  "release、部署、生产环境或不可逆外部副作用" \
+  "required live E2E、full-auto 或自动 merge" \
+  "风险无法可靠判断" \
+  "Verification Evidence Reuse Contract" \
+  "deterministic-local" \
+  "environment-dependent" \
+  '`post_integration_verify_summary.status`: `reused`' \
+  "任何无法确认的情况默认重跑"
+
+goal_skill="$repo_root/template/.agents/skills/issue-goal-prompt/SKILL.md"
+goal_reference="$repo_root/template/.agents/skills/issue-goal-prompt/references/goal-prompt-template.md"
+assert_patterns "$goal_skill" \
+  '派生 `review_policy`' \
+  '兼容性默认值是 `strict`' \
+  '`subagent_review_required` 等于 `review_policy == strict`' \
+  "对抗式自审" \
+  "验证证据复用"
+assert_patterns "$goal_reference" \
+  '- review_policy: <standard|strict>' \
+  '- subagent_review_required: <true|false>' \
+  "review_owner: main-agent-self-review" \
+  "review_owner: subagent" \
+  '`evidence_id`' \
+  '`execution_session_id`' \
+  '`deterministic-local` / `environment-dependent` / `live`' \
+  '`post_integration_verify_summary.status`: `reused`' \
+  '- `review_policy`: <standard|strict>' \
+  '- `subagent_review_required`: <true|false>'
+
+for mode in full placeholder; do
+  mode_root="$repo_root/sources/agent_extensions/$mode/.agents"
+  assert_patterns "$mode_root/prompts/issue-standard-workflow.md" \
+    "review_policy" \
+    "subagent_review_required" \
+    "standard" \
+    "strict" \
+    "evidence_id" \
+    "deterministic-local" \
+    "environment-dependent" \
+    "reused"
+  assert_patterns "$mode_root/prompts/loop-codex.md" \
+    "review_policy" \
+    "subagent_review_required" \
+    "evidence_id" \
+    "同一执行 session" \
+    "required live E2E"
+  assert_patterns "$mode_root/prompts/loop-automation.md" \
+    "review_policy" \
+    '兼容性默认 `strict`' \
+    "strict" \
+    "evidence_id" \
+    "任何无法确认的情况默认重跑"
+  assert_patterns "$mode_root/prompts/orchestrator-thread.md" \
+    "review_policy" \
+    "subagent_review_required" \
+    "多仓" \
+    "多个可写 lease" \
+    "post_integration_verify_summary.status" \
+    "reused"
+  assert_patterns "$mode_root/guides/code-review.md" \
+    "Review Policy" \
+    "main-agent-self-review" \
+    "subagent" \
+    "blocking_findings" \
+    "对抗式自审"
+done
+
+if rg -n 'review_policy|evidence_id|post_integration_verify_summary.status' \
+  "$repo_root/template/.agents/PLANS.md" \
+  "$repo_root/template/.agents/plans/TEMPLATE.md" \
+  "$repo_root/template/.agents/plans/EXAMPLE-implementation.md" >/dev/null; then
+  fail "review/evidence optimization must not change the human-readable plan contract"
+fi
+
+echo "policy contract tests passed"

--- a/tests/source_verify_contract_test.sh
+++ b/tests/source_verify_contract_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  echo "source verify contract test: $*" >&2
+  exit 1
+}
+
+expect_source_pass() {
+  local root="$1"
+  local label="$2"
+  local output
+
+  output="$(mktemp -t harness-source-pass)"
+
+  if ! HARNESS_SOURCE_SKIP_EXTERNAL_TESTS=1 \
+    bash "$root/scripts/verify_harness_source.sh" >"$output" 2>&1; then
+    sed -n '1,160p' "$output" >&2
+    rm -f "$output"
+    fail "$label should pass source verification"
+  fi
+  rm -f "$output"
+}
+
+expect_source_fail() {
+  local root="$1"
+  local label="$2"
+  local output
+
+  output="$(mktemp -t harness-source-fail)"
+  if HARNESS_SOURCE_SKIP_EXTERNAL_TESTS=1 \
+    bash "$root/scripts/verify_harness_source.sh" >"$output" 2>&1; then
+    rm -f "$output"
+    fail "$label should fail source verification"
+  fi
+  rm -f "$output"
+}
+
+new_source_fixture() {
+  local destination="$1"
+
+  mkdir -p "$destination/scripts"
+  cp -R "$repo_root/template" "$destination/template"
+  cp -R "$repo_root/sources" "$destination/sources"
+  cp "$repo_root/scripts/init_harness_project.sh" "$destination/scripts/"
+  cp "$repo_root/scripts/init_harness_project.ps1" "$destination/scripts/"
+  cp "$repo_root/scripts/verify_harness_source.sh" "$destination/scripts/"
+  cp "$repo_root/scripts/verify_harness_source.ps1" "$destination/scripts/"
+  cp "$repo_root/README.md" "$destination/"
+  cp "$repo_root/agent-init-project.md" "$destination/"
+  cp "$repo_root/init-harness-project-sop.md" "$destination/"
+  cp "$repo_root/Makefile" "$destination/"
+}
+
+for path in \
+  "$repo_root/Makefile" \
+  "$repo_root/scripts/verify_harness_source.sh" \
+  "$repo_root/scripts/verify_harness_source.ps1"; do
+  [[ -f "$path" ]] || fail "missing source verification entry: $path"
+done
+
+for test_entry in \
+  'tests/evidence_helper_test.sh' \
+  'tests/target_check_contract_test.sh' \
+  'tests/policy_contract_test.sh'; do
+  rg -Fq -- "$test_entry" "$repo_root/scripts/verify_harness_source.sh" \
+    || fail "source verification entry must execute $test_entry"
+done
+
+expect_source_pass "$repo_root" "repository baseline"
+
+tmp_root="$(mktemp -d -t harness-source-verify-test)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+wording="$tmp_root/wording"
+new_source_fixture "$wording"
+perl -0pi -e 's/## Maintenance Loop/## Maintenance Cycle/' \
+  "$wording/template/docs/harness/control-plane.md"
+expect_source_fail "$wording" "control-plane contract drift"
+
+plan_contract="$tmp_root/plan-contract"
+new_source_fixture "$plan_contract"
+perl -0pi -e 's/## Reference Snippets/## Reference Samples/' \
+  "$plan_contract/template/.agents/plans/TEMPLATE.md"
+expect_source_fail "$plan_contract" "plan template contract drift"
+
+powershell_contract="$tmp_root/powershell-contract"
+new_source_fixture "$powershell_contract"
+perl -0pi -e 's/Get-PlanImplementationSkeletonErrors/Get-PlanSkeletonErrors/g' \
+  "$powershell_contract/template/scripts/harness/common.ps1"
+expect_source_fail "$powershell_contract" "PowerShell gate contract drift"
+
+policy_contract="$tmp_root/policy-contract"
+new_source_fixture "$policy_contract"
+while IFS= read -r -d '' path; do
+  perl -0pi -e 's/review_policy/review_strategy/g; s/evidence_id/snapshot_id/g' "$path"
+done < <(find \
+  "$policy_contract/sources/agent_extensions/full" \
+  "$policy_contract/sources/agent_extensions/placeholder" \
+  -type f -print0)
+expect_source_fail "$policy_contract" "extension review/evidence contract drift"
+
+echo "source verify contract tests passed"

--- a/tests/target_check_contract_test.sh
+++ b/tests/target_check_contract_test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+template_root="$repo_root/template"
+
+fail() {
+  echo "target check contract test: $*" >&2
+  exit 1
+}
+
+new_target() {
+  local destination="$1"
+
+  mkdir -p "$destination"
+  cp -R "$template_root/." "$destination/"
+  while IFS= read -r -d '' path; do
+    perl -0pi -e \
+      's/__PROJECT_NAME__/Harness Test/g; s/__PROVIDER__/neutral/g; s/__ISSUE_PROVIDER__/linear/g; s/__ISSUE_PREFIX__/TST/g' \
+      "$path"
+  done < <(rg -l -0 --hidden '__PROJECT_NAME__|__PROVIDER__|__ISSUE_PROVIDER__|__ISSUE_PREFIX__' "$destination" || true)
+}
+
+expect_pass() {
+  local target="$1"
+  local label="$2"
+
+  if ! (cd "$target" && bash scripts/harness/check.sh) >"$target/check.out" 2>&1; then
+    sed -n '1,120p' "$target/check.out" >&2
+    fail "$label should pass"
+  fi
+}
+
+expect_fail() {
+  local target="$1"
+  local label="$2"
+
+  if (cd "$target" && bash scripts/harness/check.sh) >"$target/check.out" 2>&1; then
+    fail "$label should fail"
+  fi
+}
+
+tmp_root="$(mktemp -d -t harness-target-check-test)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+untouched="$tmp_root/untouched-template"
+mkdir -p "$untouched"
+cp -R "$template_root/." "$untouched/"
+expect_fail "$untouched" "untouched source template copied as a target"
+
+fake_source_root="$tmp_root/fake-source-root"
+mkdir -p \
+  "$fake_source_root/scripts" \
+  "$fake_source_root/sources/agent_extensions" \
+  "$fake_source_root/not-template"
+: >"$fake_source_root/scripts/verify_harness_source.sh"
+: >"$fake_source_root/scripts/verify_harness_source.ps1"
+cp -R "$template_root/." "$fake_source_root/not-template/"
+expect_fail "$fake_source_root/not-template" "source sentinel outside the canonical template directory"
+
+baseline="$tmp_root/baseline"
+new_target "$baseline"
+expect_pass "$baseline" "baseline target"
+
+wording="$tmp_root/wording"
+new_target "$wording"
+perl -0pi -e 's/## Maintenance Loop/## Maintenance Cycle/' "$wording/docs/harness/control-plane.md"
+expect_pass "$wording" "non-contract wording change"
+
+missing="$tmp_root/missing"
+new_target "$missing"
+rm -f "$missing/AGENTS.md"
+expect_fail "$missing" "missing core file"
+
+placeholder="$tmp_root/placeholder"
+new_target "$placeholder"
+printf '\nUnresolved: __PROJECT_NAME__\n' >>"$placeholder/README.md"
+expect_fail "$placeholder" "unresolved initializer placeholder"
+
+invalid_provider="$tmp_root/invalid-provider"
+new_target "$invalid_provider"
+perl -0pi -e 's/(当前 merge provider：\n\n)- `neutral`/${1}- `invalid`/' \
+  "$invalid_provider/docs/harness/control-plane.md"
+expect_fail "$invalid_provider" "invalid merge provider"
+
+mixed_mode="$tmp_root/mixed-mode"
+new_target "$mixed_mode"
+cp -R "$repo_root/sources/agent_extensions/shared/." "$mixed_mode/"
+cp -R "$repo_root/sources/agent_extensions/full/." "$mixed_mode/"
+perl -0pi -e 's/^Mode: full/Mode: placeholder/' \
+  "$mixed_mode/.agents/prompts/loop-codex.md"
+expect_fail "$mixed_mode" "mixed extension mode"
+
+powershell_check="$template_root/scripts/harness/check.ps1"
+for pattern in \
+  'evidence.ps1' \
+  'Unresolved harness initializer placeholder detected' \
+  'Optional agent extension bundle has mixed modes' \
+  'harness check passed'; do
+  rg -Fq -- "$pattern" "$powershell_check" \
+    || fail "PowerShell target check missing runtime contract: $pattern"
+done
+for source_only_pattern in \
+  'requiredControlPlanePatterns' \
+  'requiredPlansPatterns' \
+  'tmpBadPlanNoSteps' \
+  'tmpBadPlanHarnessFlow'; do
+  if rg -Fq -- "$source_only_pattern" "$powershell_check"; then
+    fail "PowerShell target check still contains source-only contract: $source_only_pattern"
+  fi
+done
+
+echo "target check contract tests passed"


### PR DESCRIPTION
## 目标

发布 harness gate 优化，拆分源仓完整回归与目标仓日常检查，并补齐可复用验证证据与分级评审策略。

## 主要改动

- 新增根级 `make verify` 与 Bash / PowerShell source verify，目标仓 `harness-verify` 只保留运行时关键不变量。
- 新增 evidence snapshot helper，对 HEAD、暂存区、工作区、未跟踪文件和 submodule 生成稳定指纹。
- 引入 `review_policy=standard|strict` 及严格的验证证据复用边界，保持 Issue 状态机、plan contract 与 review gate 接口兼容。
- 同步初始化器、Goal Prompt、扩展 Prompt、控制面文档和四组 contract 测试。

## 验证

- `make verify`
- `make -C template harness-verify`
- `git diff --check`
- Bash 脚本 `bash -n`
- staged diff 与敏感信息扫描

## 已知限制

当前机器没有 PowerShell runtime；PowerShell 已通过静态契约与 Bash/PowerShell 双端一致性检查，未宣称完成真实 runtime 执行。